### PR TITLE
Create CHANGELOG.md, CHANGELOG-PENDING.md, and corresponding GH action

### DIFF
--- a/.github/workflows/pending-changelog-checker.yml
+++ b/.github/workflows/pending-changelog-checker.yml
@@ -1,0 +1,22 @@
+name: "Pending Changelog Checker"
+
+on:
+  pull_request:
+    types: [assigned, opened, synchronize, reopened, labeled, unlabeled]
+    branches:
+      - master
+
+jobs:
+  changelog-checker:
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: "Checkout source code"
+        uses: "actions/checkout@v2"
+      - name: Changelog check
+        uses: celestiaorg/changelog-checker@v1
+        with:
+          fileName: CHANGELOG-PENDING.md
+          checkNotification: Simple
+          noChangeLogLabel: no_changelog
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG-PENDING.md
+++ b/CHANGELOG-PENDING.md
@@ -1,0 +1,21 @@
+# Unreleased Changes
+
+## vX.Y.Z
+
+Month, DD, YYYY
+
+### BREAKING CHANGES
+
+- [go package] (Link to PR) Description @username
+
+### FEATURES
+
+- [go package] (Link to PR) Description @username
+
+### IMPROVEMENTS
+
+- [go package] (Link to PR) Description @username
+
+### BUG FIXES
+
+- [go package] (Link to PR) Description @username

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Unreleased Changes
+
+## vX.Y.Z
+
+Month, DD, YYYY
+
+### BREAKING CHANGES
+
+- [go package] (Link to PR) Description @username
+
+### FEATURES
+
+- [go package] (Link to PR) Description @username
+
+### IMPROVEMENTS
+
+- [go package] (Link to PR) Description @username
+
+### BUG FIXES
+
+- [go package] (Link to PR) Description @username


### PR DESCRIPTION
Create CHANGELOG.md and CHANGELOG-PENDING.md files and a corresponding "Pending Changelog Checker" action that runs on all PRs to the master branch.

This check will only pass if the CHANGELOG-PENDING.md file is updated in the PR.

This check can be bypassed by labeling the PR with no_changelog

Resolve #62 