### PR TITLE
Return repaired eds in case of errors : ErrUnrepairableDataSquare,ErrByzantineRow, ErrByzantineCol

### DIFF
--- a/extendeddatacrossword.go
+++ b/extendeddatacrossword.go
@@ -15,6 +15,9 @@ const (
 // ErrUnrepairableDataSquare is thrown when there is insufficient chunks to repair the square.
 var ErrUnrepairableDataSquare = errors.New("failed to solve data square")
 
+// ErrNoChunksAvailable is thrown when dataSquare is empty
+var ErrNoChunksAvailable = errors.New("no chunks available")
+
 // ErrByzantineRow is thrown when a repaired row does not match the expected row Merkle root.
 type ErrByzantineRow struct {
 	RowNumber uint     // Row index
@@ -77,7 +80,7 @@ func RepairExtendedDataSquare(
 	}
 
 	if chunkSize == 0 {
-		return nil, ErrUnrepairableDataSquare
+		return nil, ErrNoChunksAvailable
 	}
 
 	fillerChunk := bytes.Repeat([]byte{0}, chunkSize)

--- a/extendeddatacrossword.go
+++ b/extendeddatacrossword.go
@@ -25,6 +25,13 @@ func (e *ErrByzantineRow) Error() string {
 	return fmt.Sprintf("byzantine row: %d", e.RowNumber)
 }
 
+// checks if error equal to ErrByzantineRow/ErrByzantineCol
+func isByzantineError(err error) bool {
+	var errRow *ErrByzantineRow
+	var errCol *ErrByzantineCol
+	return errors.As(err, &errRow) || errors.As(err, &errCol)
+}
+
 // ErrByzantineCol is thrown when a repaired column does not match the expected column Merkle root.
 type ErrByzantineCol struct {
 	ColNumber uint     // Column index
@@ -45,7 +52,7 @@ func (e *ErrByzantineCol) Error() string {
 //
 // Output
 //
-// The EDS is modified in-place. If repairing is successful, the EDS will be
+// If repairing is successful, the EDS will be
 // complete. If repairing is unsuccessful, the EDS will be the most-repaired
 // prior to the Byzantine row or column being repaired, and the Byzantine row
 // or column prior to repair is returned in the error with missing shares as
@@ -88,15 +95,13 @@ func RepairExtendedDataSquare(
 
 	err = eds.prerepairSanityCheck(rowRoots, colRoots, bitMat, codec)
 	if err != nil {
+		if isByzantineError(err) {
+			return eds, err
+		}
 		return nil, err
 	}
 
-	err = eds.solveCrossword(rowRoots, colRoots, bitMat, codec)
-	if err != nil {
-		return nil, err
-	}
-
-	return eds, err
+	return eds, eds.solveCrossword(rowRoots, colRoots, bitMat, codec)
 }
 
 // solveCrossword attempts to iteratively repair an EDS.

--- a/extendeddatacrossword_test.go
+++ b/extendeddatacrossword_test.go
@@ -56,9 +56,14 @@ func TestRepairExtendedDataSquare(t *testing.T) {
 		flattened[4], flattened[5], flattened[6], flattened[7] = nil, nil, nil, nil
 		flattened[8], flattened[9], flattened[10] = nil, nil, nil
 		flattened[12], flattened[13], flattened[14] = nil, nil, nil
-		_, err = RepairExtendedDataSquare(original.getRowRoots(), original.getColRoots(), flattened, codec, NewDefaultTree)
+
+		var extHeader *ExtendedDataSquare
+		extHeader, err = RepairExtendedDataSquare(original.getRowRoots(), original.getColRoots(), flattened, codec, NewDefaultTree)
 		if err == nil {
 			t.Errorf("did not return an error on trying to repair an unrepairable square")
+		}
+		if extHeader == nil {
+			t.Errorf("did not return a repaired EDS")
 		}
 		var corrupted ExtendedDataSquare
 		corrupted, err = original.deepCopy(codec)
@@ -77,12 +82,14 @@ func TestRepairExtendedDataSquare(t *testing.T) {
 			t.Fatalf("unexpected err while copying original data: %v, codec: :%s", err, codecName)
 		}
 		corrupted.setCell(0, 0, corruptChunk)
-		_, err = RepairExtendedDataSquare(corrupted.getRowRoots(), corrupted.getColRoots(), corrupted.flattened(), codec, NewDefaultTree)
+		extHeader, err = RepairExtendedDataSquare(corrupted.getRowRoots(), corrupted.getColRoots(), corrupted.flattened(), codec, NewDefaultTree)
 		var byzRow *ErrByzantineRow
 		if !errors.As(err, &byzRow) {
 			t.Errorf("did not return a ErrByzantineRow for a bad row; got: %v", err)
 		}
-
+		if extHeader == nil {
+			t.Errorf("did not return a repaired EDS")
+		}
 		// Construct the fraud proof
 		fraudProof := PseudoFraudProof{row, byzRow.RowNumber, byzRow.Shares}
 		// Verify the fraud proof
@@ -109,9 +116,12 @@ func TestRepairExtendedDataSquare(t *testing.T) {
 			t.Fatalf("unexpected err while copying original data: %v, codec: :%s", err, codecName)
 		}
 		corrupted.setCell(0, 3, corruptChunk)
-		_, err = RepairExtendedDataSquare(corrupted.getRowRoots(), corrupted.getColRoots(), corrupted.flattened(), codec, NewDefaultTree)
+		extHeader, err = RepairExtendedDataSquare(corrupted.getRowRoots(), corrupted.getColRoots(), corrupted.flattened(), codec, NewDefaultTree)
 		if !errors.As(err, &byzRow) {
 			t.Errorf("did not return a ErrByzantineRow for a bad row; got %v", err)
+		}
+		if extHeader == nil {
+			t.Errorf("did not return a repaired EDS")
 		}
 
 		corrupted, err = original.deepCopy(codec)
@@ -121,12 +131,14 @@ func TestRepairExtendedDataSquare(t *testing.T) {
 		corrupted.setCell(0, 0, corruptChunk)
 		flattened = corrupted.flattened()
 		flattened[1], flattened[2], flattened[3] = nil, nil, nil
-		_, err = RepairExtendedDataSquare(corrupted.getRowRoots(), corrupted.getColRoots(), flattened, codec, NewDefaultTree)
+		extHeader, err = RepairExtendedDataSquare(corrupted.getRowRoots(), corrupted.getColRoots(), flattened, codec, NewDefaultTree)
 		var byzCol *ErrByzantineCol
 		if !errors.As(err, &byzCol) {
 			t.Errorf("did not return a ErrByzantineCol for a bad column; got %v", err)
 		}
-
+		if extHeader == nil {
+			t.Errorf("did not return a repaired EDS")
+		}
 		corrupted, err = original.deepCopy(codec)
 		if err != nil {
 			t.Fatalf("unexpected err while copying original data: %v, codec: :%s", err, codecName)
@@ -134,9 +146,12 @@ func TestRepairExtendedDataSquare(t *testing.T) {
 		corrupted.setCell(3, 0, corruptChunk)
 		flattened = corrupted.flattened()
 		flattened[1], flattened[2], flattened[3] = nil, nil, nil
-		_, err = RepairExtendedDataSquare(corrupted.getRowRoots(), corrupted.getColRoots(), flattened, codec, NewDefaultTree)
+		extHeader, err = RepairExtendedDataSquare(corrupted.getRowRoots(), corrupted.getColRoots(), flattened, codec, NewDefaultTree)
 		if !errors.As(err, &byzCol) {
 			t.Errorf("did not return a ErrByzantineCol for a bad column; got %v", err)
+		}
+		if extHeader == nil {
+			t.Errorf("did not return a repaired EDS")
 		}
 	}
 }

--- a/extendeddatacrossword_test.go
+++ b/extendeddatacrossword_test.go
@@ -57,12 +57,12 @@ func TestRepairExtendedDataSquare(t *testing.T) {
 		flattened[8], flattened[9], flattened[10] = nil, nil, nil
 		flattened[12], flattened[13], flattened[14] = nil, nil, nil
 
-		var extHeader *ExtendedDataSquare
-		extHeader, err = RepairExtendedDataSquare(original.getRowRoots(), original.getColRoots(), flattened, codec, NewDefaultTree)
+		var eds *ExtendedDataSquare
+		eds, err = RepairExtendedDataSquare(original.getRowRoots(), original.getColRoots(), flattened, codec, NewDefaultTree)
 		if err == nil {
 			t.Errorf("did not return an error on trying to repair an unrepairable square")
 		}
-		if extHeader == nil {
+		if eds == nil {
 			t.Errorf("did not return a repaired EDS")
 		}
 		var corrupted ExtendedDataSquare
@@ -82,12 +82,12 @@ func TestRepairExtendedDataSquare(t *testing.T) {
 			t.Fatalf("unexpected err while copying original data: %v, codec: :%s", err, codecName)
 		}
 		corrupted.setCell(0, 0, corruptChunk)
-		extHeader, err = RepairExtendedDataSquare(corrupted.getRowRoots(), corrupted.getColRoots(), corrupted.flattened(), codec, NewDefaultTree)
+		eds, err = RepairExtendedDataSquare(corrupted.getRowRoots(), corrupted.getColRoots(), corrupted.flattened(), codec, NewDefaultTree)
 		var byzRow *ErrByzantineRow
 		if !errors.As(err, &byzRow) {
 			t.Errorf("did not return a ErrByzantineRow for a bad row; got: %v", err)
 		}
-		if extHeader == nil {
+		if eds == nil {
 			t.Errorf("did not return a repaired EDS")
 		}
 		// Construct the fraud proof
@@ -116,11 +116,11 @@ func TestRepairExtendedDataSquare(t *testing.T) {
 			t.Fatalf("unexpected err while copying original data: %v, codec: :%s", err, codecName)
 		}
 		corrupted.setCell(0, 3, corruptChunk)
-		extHeader, err = RepairExtendedDataSquare(corrupted.getRowRoots(), corrupted.getColRoots(), corrupted.flattened(), codec, NewDefaultTree)
+		eds, err = RepairExtendedDataSquare(corrupted.getRowRoots(), corrupted.getColRoots(), corrupted.flattened(), codec, NewDefaultTree)
 		if !errors.As(err, &byzRow) {
 			t.Errorf("did not return a ErrByzantineRow for a bad row; got %v", err)
 		}
-		if extHeader == nil {
+		if eds == nil {
 			t.Errorf("did not return a repaired EDS")
 		}
 
@@ -131,12 +131,12 @@ func TestRepairExtendedDataSquare(t *testing.T) {
 		corrupted.setCell(0, 0, corruptChunk)
 		flattened = corrupted.flattened()
 		flattened[1], flattened[2], flattened[3] = nil, nil, nil
-		extHeader, err = RepairExtendedDataSquare(corrupted.getRowRoots(), corrupted.getColRoots(), flattened, codec, NewDefaultTree)
+		eds, err = RepairExtendedDataSquare(corrupted.getRowRoots(), corrupted.getColRoots(), flattened, codec, NewDefaultTree)
 		var byzCol *ErrByzantineCol
 		if !errors.As(err, &byzCol) {
 			t.Errorf("did not return a ErrByzantineCol for a bad column; got %v", err)
 		}
-		if extHeader == nil {
+		if eds == nil {
 			t.Errorf("did not return a repaired EDS")
 		}
 		corrupted, err = original.deepCopy(codec)
@@ -146,11 +146,11 @@ func TestRepairExtendedDataSquare(t *testing.T) {
 		corrupted.setCell(3, 0, corruptChunk)
 		flattened = corrupted.flattened()
 		flattened[1], flattened[2], flattened[3] = nil, nil, nil
-		extHeader, err = RepairExtendedDataSquare(corrupted.getRowRoots(), corrupted.getColRoots(), flattened, codec, NewDefaultTree)
+		eds, err = RepairExtendedDataSquare(corrupted.getRowRoots(), corrupted.getColRoots(), flattened, codec, NewDefaultTree)
 		if !errors.As(err, &byzCol) {
 			t.Errorf("did not return a ErrByzantineCol for a bad column; got %v", err)
 		}
-		if extHeader == nil {
+		if eds == nil {
 			t.Errorf("did not return a repaired EDS")
 		}
 	}

--- a/extendeddatacrossword_test.go
+++ b/extendeddatacrossword_test.go
@@ -193,7 +193,7 @@ func TestRepairExtendedDataSquare(t *testing.T) {
 			t.Fatal("col roots of EDSes do not match: eds after solving: ", edsNew.ColRoots(), ",eds after repairing: ", eds.ColRoots())
 		}
 		if !reflect.DeepEqual(edsNew.RowRoots(), eds.RowRoots()) {
-			t.Fatal("col roots of EDSes do not match: eds after solving: ", edsNew.RowRoots(), ", eds after repairing: ", eds.RowRoots())
+			t.Fatal("row roots of EDSes do not match: eds after solving: ", edsNew.RowRoots(), ", eds after repairing: ", eds.RowRoots())
 		}
 	}
 }


### PR DESCRIPTION
Related to #65 

As EDS is not modified in place, then we need to return it in case of errors.