### PR TITLE
Unify byz row and col errors.

### DIFF
--- a/extendeddatacrossword.go
+++ b/extendeddatacrossword.go
@@ -14,14 +14,14 @@ const (
 // ErrUnrepairableDataSquare is thrown when there is insufficient chunks to repair the square.
 var ErrUnrepairableDataSquare = errors.New("failed to solve data square")
 
-// ErrByzantineRowOrCol is thrown when a repaired row or column does not match the expected row or column Merkle root.
-type ErrByzantineRowOrCol struct {
+// ErrByzantineData is thrown when a repaired row or column does not match the expected row or column Merkle root.
+type ErrByzantineData struct {
 	isRow  bool     // Is row.
 	Index  uint     // Row/Col index.
 	Shares [][]byte // Pre-repaired shares. Missing shares are nil.
 }
 
-func (e *ErrByzantineRowOrCol) Error() string {
+func (e *ErrByzantineData) Error() string {
 	if e.isRow {
 		return fmt.Sprintf("byzantine row: %d", e.Index)
 	} else {
@@ -30,12 +30,12 @@ func (e *ErrByzantineRowOrCol) Error() string {
 }
 
 // IsRow returns if the error is a row or not.
-func (e *ErrByzantineRowOrCol) IsRow() bool {
+func (e *ErrByzantineData) IsRow() bool {
 	return e.isRow
 }
 
 // IsCol returns if the error is a column or not.
-func (e *ErrByzantineRowOrCol) IsCol() bool {
+func (e *ErrByzantineData) IsCol() bool {
 	return !e.isRow
 }
 
@@ -267,7 +267,7 @@ func (eds *ExtendedDataSquare) verifyAgainstRowRoots(
 	root := eds.computeSharesRoot(shares, r)
 
 	if !bytes.Equal(root, rowRoots[r]) {
-		return &ErrByzantineRowOrCol{true, r, shares}
+		return &ErrByzantineData{true, r, shares}
 	}
 
 	return nil
@@ -281,7 +281,7 @@ func (eds *ExtendedDataSquare) verifyAgainstColRoots(
 	root := eds.computeSharesRoot(shares, c)
 
 	if !bytes.Equal(root, colRoots[c]) {
-		return &ErrByzantineRowOrCol{false, c, shares}
+		return &ErrByzantineData{false, c, shares}
 	}
 
 	return nil
@@ -318,7 +318,7 @@ func (eds *ExtendedDataSquare) prerepairSanityCheck(
 				return err
 			}
 			if !bytes.Equal(flattenChunks(parityShares), flattenChunks(eds.rowSlice(i, eds.originalDataWidth, eds.originalDataWidth))) {
-				return &ErrByzantineRowOrCol{true, i, eds.row(i)}
+				return &ErrByzantineData{true, i, eds.row(i)}
 			}
 		}
 
@@ -328,7 +328,7 @@ func (eds *ExtendedDataSquare) prerepairSanityCheck(
 				return err
 			}
 			if !bytes.Equal(flattenChunks(parityShares), flattenChunks(eds.colSlice(eds.originalDataWidth, i, eds.originalDataWidth))) {
-				return &ErrByzantineRowOrCol{false, i, eds.col(i)}
+				return &ErrByzantineData{false, i, eds.col(i)}
 			}
 		}
 	}

--- a/extendeddatacrossword.go
+++ b/extendeddatacrossword.go
@@ -25,10 +25,13 @@ type ErrByzantineData struct {
 }
 
 func (e *ErrByzantineData) Error() string {
-	if e.Axis == Row {
+	switch e.Axis {
+	case Row:
 		return fmt.Sprintf("byzantine row: %d", e.Index)
-	} else {
+	case Col:
 		return fmt.Sprintf("byzantine column: %d", e.Index)
+	default:
+		panic(fmt.Sprintf("invalid axis: %d", e.Axis))
 	}
 }
 

--- a/extendeddatacrossword.go
+++ b/extendeddatacrossword.go
@@ -7,11 +7,11 @@ import (
 )
 
 // axis represents which of a row or col.
-type axis int
+type Axis int
 
 const (
-	row axis = iota
-	col
+	Row Axis = iota
+	Col
 )
 
 // ErrUnrepairableDataSquare is thrown when there is insufficient chunks to repair the square.
@@ -19,27 +19,17 @@ var ErrUnrepairableDataSquare = errors.New("failed to solve data square")
 
 // ErrByzantineData is thrown when a repaired row or column does not match the expected row or column Merkle root.
 type ErrByzantineData struct {
-	axis   axis     // Axis of the data.
+	Axis   Axis     // Axis of the data.
 	Index  uint     // Row/Col index.
 	Shares [][]byte // Pre-repaired shares. Missing shares are nil.
 }
 
 func (e *ErrByzantineData) Error() string {
-	if e.axis == row {
+	if e.Axis == Row {
 		return fmt.Sprintf("byzantine row: %d", e.Index)
 	} else {
 		return fmt.Sprintf("byzantine column: %d", e.Index)
 	}
-}
-
-// IsRow returns if the error is a row or not.
-func (e *ErrByzantineData) IsRow() bool {
-	return e.axis == row
-}
-
-// IsCol returns if the error is a column or not.
-func (e *ErrByzantineData) IsCol() bool {
-	return e.axis == col
 }
 
 // Repair attempts to repair an incomplete extended data
@@ -270,7 +260,7 @@ func (eds *ExtendedDataSquare) verifyAgainstRowRoots(
 	root := eds.computeSharesRoot(shares, r)
 
 	if !bytes.Equal(root, rowRoots[r]) {
-		return &ErrByzantineData{row, r, shares}
+		return &ErrByzantineData{Row, r, shares}
 	}
 
 	return nil
@@ -284,7 +274,7 @@ func (eds *ExtendedDataSquare) verifyAgainstColRoots(
 	root := eds.computeSharesRoot(shares, c)
 
 	if !bytes.Equal(root, colRoots[c]) {
-		return &ErrByzantineData{col, c, shares}
+		return &ErrByzantineData{Col, c, shares}
 	}
 
 	return nil
@@ -321,7 +311,7 @@ func (eds *ExtendedDataSquare) prerepairSanityCheck(
 				return err
 			}
 			if !bytes.Equal(flattenChunks(parityShares), flattenChunks(eds.rowSlice(i, eds.originalDataWidth, eds.originalDataWidth))) {
-				return &ErrByzantineData{row, i, eds.row(i)}
+				return &ErrByzantineData{Row, i, eds.row(i)}
 			}
 		}
 
@@ -331,7 +321,7 @@ func (eds *ExtendedDataSquare) prerepairSanityCheck(
 				return err
 			}
 			if !bytes.Equal(flattenChunks(parityShares), flattenChunks(eds.colSlice(eds.originalDataWidth, i, eds.originalDataWidth))) {
-				return &ErrByzantineData{col, i, eds.col(i)}
+				return &ErrByzantineData{Col, i, eds.col(i)}
 			}
 		}
 	}

--- a/extendeddatacrossword.go
+++ b/extendeddatacrossword.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 )
 
-// axis represents which of a row or col.
+// Axis represents which of a row or col.
 type Axis int
 
 const (

--- a/extendeddatacrossword_test.go
+++ b/extendeddatacrossword_test.go
@@ -94,12 +94,12 @@ func TestRepairExtendedDataSquare(t *testing.T) {
 		}
 		corrupted.setCell(0, 0, corruptChunk)
 		err = corrupted.Repair(corrupted.getRowRoots(), corrupted.getColRoots(), codec, NewDefaultTree)
-		var byzRowOrCol *ErrByzantineRowOrCol
-		if !errors.As(err, &byzRowOrCol) || !byzRowOrCol.IsRow() {
-			t.Errorf("did not return a ErrByzantineRowOrCol for a bad row; got: %v", err)
+		var byzData *ErrByzantineData
+		if !errors.As(err, &byzData) || !byzData.IsRow() {
+			t.Errorf("did not return a ErrByzantineData for a bad row; got: %v", err)
 		}
 		// Construct the fraud proof
-		fraudProof := PseudoFraudProof{row, byzRowOrCol.Index, byzRowOrCol.Shares}
+		fraudProof := PseudoFraudProof{row, byzData.Index, byzData.Shares}
 		// Verify the fraud proof
 		// TODO in a real fraud proof, also verify Merkle proof for each non-nil share.
 		rebuiltShares, err := codec.Decode(fraudProof.Shares)
@@ -125,8 +125,8 @@ func TestRepairExtendedDataSquare(t *testing.T) {
 		}
 		corrupted.setCell(0, 3, corruptChunk)
 		err = corrupted.Repair(corrupted.getRowRoots(), corrupted.getColRoots(), codec, NewDefaultTree)
-		if !errors.As(err, &byzRowOrCol) || !byzRowOrCol.IsRow() {
-			t.Errorf("did not return a ErrByzantineRowOrCol for a bad row; got %v", err)
+		if !errors.As(err, &byzData) || !byzData.IsRow() {
+			t.Errorf("did not return a ErrByzantineData for a bad row; got %v", err)
 		}
 
 		corrupted, err = original.deepCopy(codec)
@@ -138,8 +138,8 @@ func TestRepairExtendedDataSquare(t *testing.T) {
 		corrupted.setCell(0, 2, nil)
 		corrupted.setCell(0, 3, nil)
 		err = corrupted.Repair(corrupted.getRowRoots(), corrupted.getColRoots(), codec, NewDefaultTree)
-		if !errors.As(err, &byzRowOrCol) || !byzRowOrCol.IsCol() {
-			t.Errorf("did not return a ErrByzantineRowOrCol for a bad column; got %v", err)
+		if !errors.As(err, &byzData) || !byzData.IsCol() {
+			t.Errorf("did not return a ErrByzantineData for a bad column; got %v", err)
 		}
 		corrupted, err = original.deepCopy(codec)
 		if err != nil {
@@ -150,8 +150,8 @@ func TestRepairExtendedDataSquare(t *testing.T) {
 		corrupted.setCell(0, 2, nil)
 		corrupted.setCell(0, 3, nil)
 		err = corrupted.Repair(corrupted.getRowRoots(), corrupted.getColRoots(), codec, NewDefaultTree)
-		if !errors.As(err, &byzRowOrCol) || !byzRowOrCol.IsCol() {
-			t.Errorf("did not return a ErrByzantineRowOrCol for a bad column; got %v", err)
+		if !errors.As(err, &byzData) || !byzData.IsCol() {
+			t.Errorf("did not return a ErrByzantineData for a bad column; got %v", err)
 		}
 	}
 }

--- a/extendeddatacrossword_test.go
+++ b/extendeddatacrossword_test.go
@@ -95,7 +95,7 @@ func TestRepairExtendedDataSquare(t *testing.T) {
 		corrupted.setCell(0, 0, corruptChunk)
 		err = corrupted.Repair(corrupted.getRowRoots(), corrupted.getColRoots(), codec, NewDefaultTree)
 		var byzData *ErrByzantineData
-		if !errors.As(err, &byzData) || !byzData.IsRow() {
+		if !errors.As(err, &byzData) || byzData.Axis != Row {
 			t.Errorf("did not return a ErrByzantineData for a bad row; got: %v", err)
 		}
 		// Construct the fraud proof
@@ -125,7 +125,7 @@ func TestRepairExtendedDataSquare(t *testing.T) {
 		}
 		corrupted.setCell(0, 3, corruptChunk)
 		err = corrupted.Repair(corrupted.getRowRoots(), corrupted.getColRoots(), codec, NewDefaultTree)
-		if !errors.As(err, &byzData) || !byzData.IsRow() {
+		if !errors.As(err, &byzData) || byzData.Axis != Row {
 			t.Errorf("did not return a ErrByzantineData for a bad row; got %v", err)
 		}
 
@@ -138,7 +138,7 @@ func TestRepairExtendedDataSquare(t *testing.T) {
 		corrupted.setCell(0, 2, nil)
 		corrupted.setCell(0, 3, nil)
 		err = corrupted.Repair(corrupted.getRowRoots(), corrupted.getColRoots(), codec, NewDefaultTree)
-		if !errors.As(err, &byzData) || !byzData.IsCol() {
+		if !errors.As(err, &byzData) || byzData.Axis != Col {
 			t.Errorf("did not return a ErrByzantineData for a bad column; got %v", err)
 		}
 		corrupted, err = original.deepCopy(codec)
@@ -150,7 +150,7 @@ func TestRepairExtendedDataSquare(t *testing.T) {
 		corrupted.setCell(0, 2, nil)
 		corrupted.setCell(0, 3, nil)
 		err = corrupted.Repair(corrupted.getRowRoots(), corrupted.getColRoots(), codec, NewDefaultTree)
-		if !errors.As(err, &byzData) || !byzData.IsCol() {
+		if !errors.As(err, &byzData) || byzData.Axis != Col {
 			t.Errorf("did not return a ErrByzantineData for a bad column; got %v", err)
 		}
 	}

--- a/extendeddatacrossword_test.go
+++ b/extendeddatacrossword_test.go
@@ -94,12 +94,12 @@ func TestRepairExtendedDataSquare(t *testing.T) {
 		}
 		corrupted.setCell(0, 0, corruptChunk)
 		err = corrupted.Repair(corrupted.getRowRoots(), corrupted.getColRoots(), codec, NewDefaultTree)
-		var byzRow *ErrByzantineRow
-		if !errors.As(err, &byzRow) {
-			t.Errorf("did not return a ErrByzantineRow for a bad row; got: %v", err)
+		var byzRowOrCol *ErrByzantineRowOrCol
+		if !errors.As(err, &byzRowOrCol) || !byzRowOrCol.IsRow() {
+			t.Errorf("did not return a ErrByzantineRowOrCol for a bad row; got: %v", err)
 		}
 		// Construct the fraud proof
-		fraudProof := PseudoFraudProof{row, byzRow.RowNumber, byzRow.Shares}
+		fraudProof := PseudoFraudProof{row, byzRowOrCol.Index, byzRowOrCol.Shares}
 		// Verify the fraud proof
 		// TODO in a real fraud proof, also verify Merkle proof for each non-nil share.
 		rebuiltShares, err := codec.Decode(fraudProof.Shares)
@@ -125,8 +125,8 @@ func TestRepairExtendedDataSquare(t *testing.T) {
 		}
 		corrupted.setCell(0, 3, corruptChunk)
 		err = corrupted.Repair(corrupted.getRowRoots(), corrupted.getColRoots(), codec, NewDefaultTree)
-		if !errors.As(err, &byzRow) {
-			t.Errorf("did not return a ErrByzantineRow for a bad row; got %v", err)
+		if !errors.As(err, &byzRowOrCol) || !byzRowOrCol.IsRow() {
+			t.Errorf("did not return a ErrByzantineRowOrCol for a bad row; got %v", err)
 		}
 
 		corrupted, err = original.deepCopy(codec)
@@ -138,9 +138,8 @@ func TestRepairExtendedDataSquare(t *testing.T) {
 		corrupted.setCell(0, 2, nil)
 		corrupted.setCell(0, 3, nil)
 		err = corrupted.Repair(corrupted.getRowRoots(), corrupted.getColRoots(), codec, NewDefaultTree)
-		var byzCol *ErrByzantineCol
-		if !errors.As(err, &byzCol) {
-			t.Errorf("did not return a ErrByzantineCol for a bad column; got %v", err)
+		if !errors.As(err, &byzRowOrCol) || !byzRowOrCol.IsCol() {
+			t.Errorf("did not return a ErrByzantineRowOrCol for a bad column; got %v", err)
 		}
 		corrupted, err = original.deepCopy(codec)
 		if err != nil {
@@ -151,8 +150,8 @@ func TestRepairExtendedDataSquare(t *testing.T) {
 		corrupted.setCell(0, 2, nil)
 		corrupted.setCell(0, 3, nil)
 		err = corrupted.Repair(corrupted.getRowRoots(), corrupted.getColRoots(), codec, NewDefaultTree)
-		if !errors.As(err, &byzCol) {
-			t.Errorf("did not return a ErrByzantineCol for a bad column; got %v", err)
+		if !errors.As(err, &byzRowOrCol) || !byzRowOrCol.IsCol() {
+			t.Errorf("did not return a ErrByzantineRowOrCol for a bad column; got %v", err)
 		}
 	}
 }

--- a/extendeddatacrossword_test.go
+++ b/extendeddatacrossword_test.go
@@ -99,7 +99,7 @@ func TestRepairExtendedDataSquare(t *testing.T) {
 			t.Errorf("did not return a ErrByzantineData for a bad row; got: %v", err)
 		}
 		// Construct the fraud proof
-		fraudProof := PseudoFraudProof{row, byzData.Index, byzData.Shares}
+		fraudProof := PseudoFraudProof{0, byzData.Index, byzData.Shares}
 		// Verify the fraud proof
 		// TODO in a real fraud proof, also verify Merkle proof for each non-nil share.
 		rebuiltShares, err := codec.Decode(fraudProof.Shares)


### PR DESCRIPTION
Fixes #78

Unifies `ErrByzantineRow` and `ErrByzantineCol` into `ErrByzantineRowOrCol`. Provides two helper methods `IsRow()` and `IsCol()` since negating `isRow` to figure out if something is a column isn't immediately obvious.