### PR TITLE
add extra build tags

### DIFF
--- a/leopard.go
+++ b/leopard.go
@@ -1,4 +1,5 @@
 //go:build leopard
+// +build leopard
 
 // Note that if the build tag leopard is used, liblibleopard.a
 // has to be present where the linker will find it.

--- a/rsmt2d_test.go
+++ b/rsmt2d_test.go
@@ -1,4 +1,5 @@
 //go:build leopard
+// +build leopard
 
 package rsmt2d_test
 


### PR DESCRIPTION
without these build tags, the go compiler will sometimes complain, such as when the e2e test for tendermint is being compiled.

after merging, we will need to create a v0.5.1 release so that core can properly import this change.