### PR TITLE
perf: check nil chunks directly to avoid copying

### DIFF
--- a/datasquare.go
+++ b/datasquare.go
@@ -231,7 +231,7 @@ func (ds *dataSquare) getColRoot(y uint) []byte {
 	return tree.Root()
 }
 
-// getCell returns a copy a single chunk at a specific cell.
+// getCell returns a copy of single chunk at a specific cell.
 func (ds *dataSquare) getCell(x uint, y uint) []byte {
 	if ds.squareRow[x][y] == nil {
 		return nil

--- a/datasquare.go
+++ b/datasquare.go
@@ -231,7 +231,7 @@ func (ds *dataSquare) getColRoot(y uint) []byte {
 	return tree.Root()
 }
 
-// getCell returns a single chunk at a specific cell.
+// getCell returns a copy a single chunk at a specific cell.
 func (ds *dataSquare) getCell(x uint, y uint) []byte {
 	if ds.squareRow[x][y] == nil {
 		return nil

--- a/extendeddatacrossword.go
+++ b/extendeddatacrossword.go
@@ -355,7 +355,7 @@ func (eds *ExtendedDataSquare) computeSharesRoot(shares [][]byte, i uint) []byte
 
 func (eds *ExtendedDataSquare) rowRangeNoMissingData(r, start, end uint) bool {
 	for c := start; c <= end && c < eds.width; c++ {
-		if eds.getCell(r, c) == nil {
+		if eds.squareRow[r][c] == nil {
 			return false
 		}
 	}
@@ -364,7 +364,7 @@ func (eds *ExtendedDataSquare) rowRangeNoMissingData(r, start, end uint) bool {
 
 func (eds *ExtendedDataSquare) colRangeNoMissingData(c, start, end uint) bool {
 	for r := start; r <= end && r < eds.width; r++ {
-		if eds.getCell(r, c) == nil {
+		if eds.squareRow[r][c]  == nil {
 			return false
 		}
 	}


### PR DESCRIPTION
`getCell` seems like another method that was supposed to become public but never got to it. I think so because it creates a copy of a chunk for encapsulation reasons, but It is only used internally now and in tests. This PR solves the problem that it avoids the use of `getCell` internally, thus avoiding copy internally, specifically in `...rangeMissingNoData`, which is just a helper func that should not do a copy for every chunk,

`getCell` won't be used anywhere after this PR is merged, so we should consider either removing it or publicizing it.