### PR TITLE
Export `SetCell` and `GetCell`.

### DIFF
--- a/datasquare.go
+++ b/datasquare.go
@@ -2,6 +2,7 @@ package rsmt2d
 
 import (
 	"errors"
+	"fmt"
 	"math"
 )
 
@@ -241,8 +242,19 @@ func (ds *dataSquare) GetCell(x uint, y uint) []byte {
 	return cell
 }
 
-// SetCell sets a specific cell.
+// SetCell sets a specific cell. Cell to set must be `nil`.
+// Panics if attempting to set a cell that is not `nil`.
 func (ds *dataSquare) SetCell(x uint, y uint, newChunk []byte) {
+	if ds.squareRow[x][y] != nil {
+		panic(fmt.Sprintf("cannot set cell (%d, %d) as it already has a value %x", x, y, ds.squareRow[x][y]))
+	}
+	ds.squareRow[x][y] = newChunk
+	ds.squareCol[y][x] = newChunk
+	ds.resetRoots()
+}
+
+// setCell sets a specific cell.
+func (ds *dataSquare) setCell(x uint, y uint, newChunk []byte) {
 	ds.squareRow[x][y] = newChunk
 	ds.squareCol[y][x] = newChunk
 	ds.resetRoots()

--- a/datasquare.go
+++ b/datasquare.go
@@ -117,7 +117,7 @@ func (ds *dataSquare) rowSlice(x uint, y uint, length uint) [][]byte {
 }
 
 // row returns a row slice.
-// Do not modify this slice directly, instead use setCell.
+// Do not modify this slice directly, instead use SetCell.
 func (ds *dataSquare) row(x uint) [][]byte {
 	return ds.rowSlice(x, 0, ds.width)
 }
@@ -144,7 +144,7 @@ func (ds *dataSquare) colSlice(x uint, y uint, length uint) [][]byte {
 }
 
 // col returns a column slice.
-// Do not modify this slice directly, instead use setCell.
+// Do not modify this slice directly, instead use SetCell.
 func (ds *dataSquare) col(y uint) [][]byte {
 	return ds.colSlice(0, y, ds.width)
 }
@@ -231,8 +231,8 @@ func (ds *dataSquare) getColRoot(y uint) []byte {
 	return tree.Root()
 }
 
-// getCell returns a copy of single chunk at a specific cell.
-func (ds *dataSquare) getCell(x uint, y uint) []byte {
+// GetCell returns a copy of a specific cell.
+func (ds *dataSquare) GetCell(x uint, y uint) []byte {
 	if ds.squareRow[x][y] == nil {
 		return nil
 	}
@@ -241,7 +241,8 @@ func (ds *dataSquare) getCell(x uint, y uint) []byte {
 	return cell
 }
 
-func (ds *dataSquare) setCell(x uint, y uint, newChunk []byte) {
+// SetCell sets a specific cell.
+func (ds *dataSquare) SetCell(x uint, y uint, newChunk []byte) {
 	ds.squareRow[x][y] = newChunk
 	ds.squareCol[y][x] = newChunk
 	ds.resetRoots()

--- a/extendeddatacrossword.go
+++ b/extendeddatacrossword.go
@@ -160,7 +160,7 @@ func (eds *ExtendedDataSquare) solveCrosswordRow(
 
 	// Insert rebuilt shares into square.
 	for c, s := range rebuiltShares {
-		eds.SetCell(uint(r), uint(c), s)
+		eds.setCell(uint(r), uint(c), s)
 	}
 
 	return true, true, nil
@@ -219,7 +219,7 @@ func (eds *ExtendedDataSquare) solveCrosswordCol(
 
 	// Insert rebuilt shares into square.
 	for r, s := range rebuiltShares {
-		eds.SetCell(uint(r), uint(c), s)
+		eds.setCell(uint(r), uint(c), s)
 	}
 
 	return true, true, nil

--- a/extendeddatacrossword.go
+++ b/extendeddatacrossword.go
@@ -160,7 +160,7 @@ func (eds *ExtendedDataSquare) solveCrosswordRow(
 
 	// Insert rebuilt shares into square.
 	for c, s := range rebuiltShares {
-		eds.setCell(uint(r), uint(c), s)
+		eds.SetCell(uint(r), uint(c), s)
 	}
 
 	return true, true, nil
@@ -219,7 +219,7 @@ func (eds *ExtendedDataSquare) solveCrosswordCol(
 
 	// Insert rebuilt shares into square.
 	for r, s := range rebuiltShares {
-		eds.setCell(uint(r), uint(c), s)
+		eds.SetCell(uint(r), uint(c), s)
 	}
 
 	return true, true, nil
@@ -364,7 +364,7 @@ func (eds *ExtendedDataSquare) rowRangeNoMissingData(r, start, end uint) bool {
 
 func (eds *ExtendedDataSquare) colRangeNoMissingData(c, start, end uint) bool {
 	for r := start; r <= end && r < eds.width; r++ {
-		if eds.squareRow[r][c]  == nil {
+		if eds.squareRow[r][c] == nil {
 			return false
 		}
 	}

--- a/extendeddatacrossword_test.go
+++ b/extendeddatacrossword_test.go
@@ -54,10 +54,10 @@ func TestRepairExtendedDataSquare(t *testing.T) {
 		if err != nil {
 			t.Errorf("unexpected err while repairing data square: %v, codec: :%s", err, codecName)
 		} else {
-			assert.Equal(t, original.getCell(0, 0), ones)
-			assert.Equal(t, original.getCell(0, 1), twos)
-			assert.Equal(t, original.getCell(1, 0), threes)
-			assert.Equal(t, original.getCell(1, 1), fours)
+			assert.Equal(t, original.GetCell(0, 0), ones)
+			assert.Equal(t, original.GetCell(0, 1), twos)
+			assert.Equal(t, original.GetCell(1, 0), threes)
+			assert.Equal(t, original.GetCell(1, 1), fours)
 		}
 
 		flattened = original.flattened()
@@ -82,7 +82,7 @@ func TestRepairExtendedDataSquare(t *testing.T) {
 			t.Fatalf("unexpected err while copying original data: %v, codec: :%s", err, codecName)
 		}
 		corruptChunk := bytes.Repeat([]byte{66}, bufferSize)
-		corrupted.setCell(0, 0, corruptChunk)
+		corrupted.SetCell(0, 0, corruptChunk)
 		err = corrupted.Repair(rowRoots, colRoots, codec, NewDefaultTree)
 		if err == nil {
 			t.Errorf("did not return an error on trying to repair a square with bad roots")
@@ -92,7 +92,7 @@ func TestRepairExtendedDataSquare(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected err while copying original data: %v, codec: :%s", err, codecName)
 		}
-		corrupted.setCell(0, 0, corruptChunk)
+		corrupted.SetCell(0, 0, corruptChunk)
 		err = corrupted.Repair(corrupted.getRowRoots(), corrupted.getColRoots(), codec, NewDefaultTree)
 		var byzData *ErrByzantineData
 		if !errors.As(err, &byzData) || byzData.Axis != Row {
@@ -123,7 +123,7 @@ func TestRepairExtendedDataSquare(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected err while copying original data: %v, codec: :%s", err, codecName)
 		}
-		corrupted.setCell(0, 3, corruptChunk)
+		corrupted.SetCell(0, 3, corruptChunk)
 		err = corrupted.Repair(corrupted.getRowRoots(), corrupted.getColRoots(), codec, NewDefaultTree)
 		if !errors.As(err, &byzData) || byzData.Axis != Row {
 			t.Errorf("did not return a ErrByzantineData for a bad row; got %v", err)
@@ -133,10 +133,10 @@ func TestRepairExtendedDataSquare(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected err while copying original data: %v, codec: :%s", err, codecName)
 		}
-		corrupted.setCell(0, 0, corruptChunk)
-		corrupted.setCell(0, 1, nil)
-		corrupted.setCell(0, 2, nil)
-		corrupted.setCell(0, 3, nil)
+		corrupted.SetCell(0, 0, corruptChunk)
+		corrupted.SetCell(0, 1, nil)
+		corrupted.SetCell(0, 2, nil)
+		corrupted.SetCell(0, 3, nil)
 		err = corrupted.Repair(corrupted.getRowRoots(), corrupted.getColRoots(), codec, NewDefaultTree)
 		if !errors.As(err, &byzData) || byzData.Axis != Col {
 			t.Errorf("did not return a ErrByzantineData for a bad column; got %v", err)
@@ -145,10 +145,10 @@ func TestRepairExtendedDataSquare(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected err while copying original data: %v, codec: :%s", err, codecName)
 		}
-		corrupted.setCell(3, 0, corruptChunk)
-		corrupted.setCell(0, 1, nil)
-		corrupted.setCell(0, 2, nil)
-		corrupted.setCell(0, 3, nil)
+		corrupted.SetCell(3, 0, corruptChunk)
+		corrupted.SetCell(0, 1, nil)
+		corrupted.SetCell(0, 2, nil)
+		corrupted.SetCell(0, 3, nil)
 		err = corrupted.Repair(corrupted.getRowRoots(), corrupted.getColRoots(), codec, NewDefaultTree)
 		if !errors.As(err, &byzData) || byzData.Axis != Col {
 			t.Errorf("did not return a ErrByzantineData for a bad column; got %v", err)

--- a/extendeddatacrossword_test.go
+++ b/extendeddatacrossword_test.go
@@ -82,7 +82,7 @@ func TestRepairExtendedDataSquare(t *testing.T) {
 			t.Fatalf("unexpected err while copying original data: %v, codec: :%s", err, codecName)
 		}
 		corruptChunk := bytes.Repeat([]byte{66}, bufferSize)
-		corrupted.SetCell(0, 0, corruptChunk)
+		corrupted.setCell(0, 0, corruptChunk)
 		err = corrupted.Repair(rowRoots, colRoots, codec, NewDefaultTree)
 		if err == nil {
 			t.Errorf("did not return an error on trying to repair a square with bad roots")
@@ -92,7 +92,7 @@ func TestRepairExtendedDataSquare(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected err while copying original data: %v, codec: :%s", err, codecName)
 		}
-		corrupted.SetCell(0, 0, corruptChunk)
+		corrupted.setCell(0, 0, corruptChunk)
 		err = corrupted.Repair(corrupted.getRowRoots(), corrupted.getColRoots(), codec, NewDefaultTree)
 		var byzData *ErrByzantineData
 		if !errors.As(err, &byzData) || byzData.Axis != Row {
@@ -123,7 +123,7 @@ func TestRepairExtendedDataSquare(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected err while copying original data: %v, codec: :%s", err, codecName)
 		}
-		corrupted.SetCell(0, 3, corruptChunk)
+		corrupted.setCell(0, 3, corruptChunk)
 		err = corrupted.Repair(corrupted.getRowRoots(), corrupted.getColRoots(), codec, NewDefaultTree)
 		if !errors.As(err, &byzData) || byzData.Axis != Row {
 			t.Errorf("did not return a ErrByzantineData for a bad row; got %v", err)
@@ -133,10 +133,10 @@ func TestRepairExtendedDataSquare(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected err while copying original data: %v, codec: :%s", err, codecName)
 		}
-		corrupted.SetCell(0, 0, corruptChunk)
-		corrupted.SetCell(0, 1, nil)
-		corrupted.SetCell(0, 2, nil)
-		corrupted.SetCell(0, 3, nil)
+		corrupted.setCell(0, 0, corruptChunk)
+		corrupted.setCell(0, 1, nil)
+		corrupted.setCell(0, 2, nil)
+		corrupted.setCell(0, 3, nil)
 		err = corrupted.Repair(corrupted.getRowRoots(), corrupted.getColRoots(), codec, NewDefaultTree)
 		if !errors.As(err, &byzData) || byzData.Axis != Col {
 			t.Errorf("did not return a ErrByzantineData for a bad column; got %v", err)
@@ -145,10 +145,10 @@ func TestRepairExtendedDataSquare(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected err while copying original data: %v, codec: :%s", err, codecName)
 		}
-		corrupted.SetCell(3, 0, corruptChunk)
-		corrupted.SetCell(0, 1, nil)
-		corrupted.SetCell(0, 2, nil)
-		corrupted.SetCell(0, 3, nil)
+		corrupted.setCell(3, 0, corruptChunk)
+		corrupted.setCell(0, 1, nil)
+		corrupted.setCell(0, 2, nil)
+		corrupted.setCell(0, 3, nil)
 		err = corrupted.Repair(corrupted.getRowRoots(), corrupted.getColRoots(), codec, NewDefaultTree)
 		if !errors.As(err, &byzData) || byzData.Axis != Col {
 			t.Errorf("did not return a ErrByzantineData for a bad column; got %v", err)


### PR DESCRIPTION
Fixes #83
Fixes #89

Unlike the suggestion in #83 to not reset cached roots, that functionality was kept. The reason is that setting a cell from `nil` to non-`nil` does not guarantee that the roots match up with the leaves. The roots actually need to be re-computed to guarantee this, so the cache is cleared every time a cell is set.