### PR TITLE
Cache codec and tree func.

### DIFF
--- a/extendeddatacrossword_test.go
+++ b/extendeddatacrossword_test.go
@@ -50,7 +50,7 @@ func TestRepairExtendedDataSquare(t *testing.T) {
 			t.Errorf("ImportExtendedDataSquare failed: %v", err)
 		}
 
-		err = eds.Repair(rowRoots, colRoots, codec, NewDefaultTree)
+		err = eds.Repair(rowRoots, colRoots)
 		if err != nil {
 			t.Errorf("unexpected err while repairing data square: %v, codec: :%s", err, codecName)
 		} else {
@@ -72,7 +72,7 @@ func TestRepairExtendedDataSquare(t *testing.T) {
 			t.Errorf("ImportExtendedDataSquare failed: %v", err)
 		}
 
-		err = eds.Repair(rowRoots, colRoots, codec, NewDefaultTree)
+		err = eds.Repair(rowRoots, colRoots)
 		if err == nil {
 			t.Errorf("did not return an error on trying to repair an unrepairable square")
 		}
@@ -83,7 +83,7 @@ func TestRepairExtendedDataSquare(t *testing.T) {
 		}
 		corruptChunk := bytes.Repeat([]byte{66}, bufferSize)
 		corrupted.setCell(0, 0, corruptChunk)
-		err = corrupted.Repair(rowRoots, colRoots, codec, NewDefaultTree)
+		err = corrupted.Repair(rowRoots, colRoots)
 		if err == nil {
 			t.Errorf("did not return an error on trying to repair a square with bad roots")
 		}
@@ -93,7 +93,7 @@ func TestRepairExtendedDataSquare(t *testing.T) {
 			t.Fatalf("unexpected err while copying original data: %v, codec: :%s", err, codecName)
 		}
 		corrupted.setCell(0, 0, corruptChunk)
-		err = corrupted.Repair(corrupted.getRowRoots(), corrupted.getColRoots(), codec, NewDefaultTree)
+		err = corrupted.Repair(corrupted.getRowRoots(), corrupted.getColRoots())
 		var byzData *ErrByzantineData
 		if !errors.As(err, &byzData) || byzData.Axis != Row {
 			t.Errorf("did not return a ErrByzantineData for a bad row; got: %v", err)
@@ -124,7 +124,7 @@ func TestRepairExtendedDataSquare(t *testing.T) {
 			t.Fatalf("unexpected err while copying original data: %v, codec: :%s", err, codecName)
 		}
 		corrupted.setCell(0, 3, corruptChunk)
-		err = corrupted.Repair(corrupted.getRowRoots(), corrupted.getColRoots(), codec, NewDefaultTree)
+		err = corrupted.Repair(corrupted.getRowRoots(), corrupted.getColRoots())
 		if !errors.As(err, &byzData) || byzData.Axis != Row {
 			t.Errorf("did not return a ErrByzantineData for a bad row; got %v", err)
 		}
@@ -137,7 +137,7 @@ func TestRepairExtendedDataSquare(t *testing.T) {
 		corrupted.setCell(0, 1, nil)
 		corrupted.setCell(0, 2, nil)
 		corrupted.setCell(0, 3, nil)
-		err = corrupted.Repair(corrupted.getRowRoots(), corrupted.getColRoots(), codec, NewDefaultTree)
+		err = corrupted.Repair(corrupted.getRowRoots(), corrupted.getColRoots())
 		if !errors.As(err, &byzData) || byzData.Axis != Col {
 			t.Errorf("did not return a ErrByzantineData for a bad column; got %v", err)
 		}
@@ -149,7 +149,7 @@ func TestRepairExtendedDataSquare(t *testing.T) {
 		corrupted.setCell(0, 1, nil)
 		corrupted.setCell(0, 2, nil)
 		corrupted.setCell(0, 3, nil)
-		err = corrupted.Repair(corrupted.getRowRoots(), corrupted.getColRoots(), codec, NewDefaultTree)
+		err = corrupted.Repair(corrupted.getRowRoots(), corrupted.getColRoots())
 		if !errors.As(err, &byzData) || byzData.Axis != Col {
 			t.Errorf("did not return a ErrByzantineData for a bad column; got %v", err)
 		}
@@ -203,8 +203,6 @@ func BenchmarkRepair(b *testing.B) {
 						err := eds.Repair(
 							rowRoots,
 							colRoots,
-							codec,
-							NewDefaultTree,
 						)
 						if err != nil {
 							b.Error(err)

--- a/extendeddatasquare.go
+++ b/extendeddatasquare.go
@@ -9,6 +9,7 @@ import (
 // ExtendedDataSquare represents an extended piece of data.
 type ExtendedDataSquare struct {
 	*dataSquare
+	codec             Codec
 	originalDataWidth uint
 }
 
@@ -27,7 +28,7 @@ func ComputeExtendedDataSquare(
 		return nil, err
 	}
 
-	eds := ExtendedDataSquare{dataSquare: ds}
+	eds := ExtendedDataSquare{dataSquare: ds, codec: codec}
 	err = eds.erasureExtendSquare(codec)
 	if err != nil {
 		return nil, err
@@ -51,7 +52,7 @@ func ImportExtendedDataSquare(
 		return nil, err
 	}
 
-	eds := ExtendedDataSquare{dataSquare: ds}
+	eds := ExtendedDataSquare{dataSquare: ds, codec: codec}
 	if eds.width%2 != 0 {
 		return nil, errors.New("square width must be even")
 	}

--- a/rsmt2d_test.go
+++ b/rsmt2d_test.go
@@ -68,8 +68,6 @@ func TestEdsRepairRoundtripSimple(t *testing.T) {
 			err = eds.Repair(
 				rowRoots,
 				colRoots,
-				tt.codec,
-				rsmt2d.NewDefaultTree,
 			)
 			if err != nil {
 				// err contains information to construct a fraud proof
@@ -140,8 +138,6 @@ func TestEdsRepairTwice(t *testing.T) {
 			err = eds.Repair(
 				rowRoots,
 				colRoots,
-				tt.codec,
-				rsmt2d.NewDefaultTree,
 			)
 			if !errors.Is(err, rsmt2d.ErrUnrepairableDataSquare) {
 				// Should fail since insufficient data.
@@ -160,8 +156,6 @@ func TestEdsRepairTwice(t *testing.T) {
 			err = eds.Repair(
 				rowRoots,
 				colRoots,
-				tt.codec,
-				rsmt2d.NewDefaultTree,
 			)
 			if err != nil {
 				// Should now pass, since sufficient data.


### PR DESCRIPTION
Fixes #82

Interestingly, the tree func was already cached, and the passed in tree func in `Repair` was unused.