### PR TITLE
Exporting `dataSquare.flattened`

### DIFF
--- a/datasquare.go
+++ b/datasquare.go
@@ -260,7 +260,8 @@ func (ds *dataSquare) setCell(x uint, y uint, newChunk []byte) {
 	ds.resetRoots()
 }
 
-func (ds *dataSquare) flattened() [][]byte {
+// Flattened returns the concatenated rows of the data square.
+func (ds *dataSquare) Flattened() [][]byte {
 	flattened := [][]byte(nil)
 	for _, data := range ds.squareRow {
 		flattened = append(flattened, data...)

--- a/datasquare_test.go
+++ b/datasquare_test.go
@@ -66,6 +66,20 @@ func TestGetCell(t *testing.T) {
 	}
 }
 
+func TestFlattened(t *testing.T) {
+	ds, err := newDataSquare([][]byte{{1}, {2}, {3}, {4}}, NewDefaultTree)
+	if err != nil {
+		panic(err)
+	}
+
+	flattened := ds.Flattened()
+	flattened[0] = []byte{42}
+
+	if reflect.DeepEqual(ds.Flattened(), [][]byte{{42}, {2}, {3}, {4}}) {
+		t.Errorf("Flattened failed to return an immutable copy")
+	}
+}
+
 func TestExtendSquare(t *testing.T) {
 	ds, err := newDataSquare([][]byte{{1, 2}}, NewDefaultTree)
 	if err != nil {

--- a/extendeddatacrossword_test.go
+++ b/extendeddatacrossword_test.go
@@ -38,7 +38,7 @@ func TestRepairExtendedDataSquare(t *testing.T) {
 		rowRoots := original.RowRoots()
 		colRoots := original.ColRoots()
 
-		flattened := original.flattened()
+		flattened := original.Flattened()
 		flattened[0], flattened[2], flattened[3] = nil, nil, nil
 		flattened[4], flattened[5], flattened[6], flattened[7] = nil, nil, nil, nil
 		flattened[8], flattened[9], flattened[10] = nil, nil, nil
@@ -60,7 +60,7 @@ func TestRepairExtendedDataSquare(t *testing.T) {
 			assert.Equal(t, original.GetCell(1, 1), fours)
 		}
 
-		flattened = original.flattened()
+		flattened = original.Flattened()
 		flattened[0], flattened[2], flattened[3] = nil, nil, nil
 		flattened[4], flattened[5], flattened[6], flattened[7] = nil, nil, nil, nil
 		flattened[8], flattened[9], flattened[10] = nil, nil, nil
@@ -182,7 +182,7 @@ func BenchmarkRepair(b *testing.B) {
 					for n := 0; n < b.N; n++ {
 						b.StopTimer()
 
-						flattened := eds.flattened()
+						flattened := eds.Flattened()
 						// Randomly remove 1/2 of the shares of each row
 						for r := 0; r < extendedDataWidth; r++ {
 							for c := 0; c < originalDataWidth; {

--- a/extendeddatasquare.go
+++ b/extendeddatasquare.go
@@ -126,7 +126,7 @@ func (eds *ExtendedDataSquare) erasureExtendSquare(codec Codec) error {
 }
 
 func (eds *ExtendedDataSquare) deepCopy(codec Codec) (ExtendedDataSquare, error) {
-	eds, err := ImportExtendedDataSquare(eds.flattened(), codec, eds.createTreeFn)
+	eds, err := ImportExtendedDataSquare(eds.Flattened(), codec, eds.createTreeFn)
 	return *eds, err
 }
 


### PR DESCRIPTION
Opened in #97 .

Since `ImportExtendedDataSquare` takes a flattened EDS, would this export make sense? 

Would allow us to slash [`ExtractEDS`](https://github.com/celestiaorg/celestia-node/blob/7f70b9b0b25cb601070d5eee59c5482bc893032e/ipld/add.go#L83-L95
) in `celestia-node/ipld` if I'm not mistaken.