### PR TITLE
testing: immutability constraints on Row, Cell, GetCell, and SetCell

### DIFF
--- a/datasquare_test.go
+++ b/datasquare_test.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestNewDataSquare(t *testing.T) {
@@ -31,6 +33,36 @@ func TestNewDataSquare(t *testing.T) {
 	_, err = newDataSquare([][]byte{{1, 2}, {3, 4}, {5, 6}, {7}}, NewDefaultTree)
 	if err == nil {
 		t.Errorf("newDataSquare failed; chunks of unequal size accepted")
+	}
+}
+
+func TestSetCell(t *testing.T) {
+	ds, err := newDataSquare([][]byte{{1}, {2}, {3}, {4}}, NewDefaultTree)
+	if err != nil {
+		panic(err)
+	}
+
+	// SetCell can only write to nil cells
+	assert.Panics(t, func() { ds.SetCell(0, 0, []byte{0}) })
+
+	// Set the cell to nil to allow modification
+	ds.setCell(0, 0, nil)
+
+	ds.SetCell(0, 0, []byte{42})
+	assert.Equal(t, []byte{42}, ds.GetCell(0, 0))
+}
+
+func TestGetCell(t *testing.T) {
+	ds, err := newDataSquare([][]byte{{1}, {2}, {3}, {4}}, NewDefaultTree)
+	if err != nil {
+		panic(err)
+	}
+
+	cell := ds.GetCell(0, 0)
+	cell[0] = 42
+
+	if reflect.DeepEqual(ds.GetCell(0, 0), []byte{42}) {
+		t.Errorf("GetCell failed to return an immutable copy of the cell")
 	}
 }
 

--- a/extendeddatasquare.go
+++ b/extendeddatasquare.go
@@ -144,24 +144,27 @@ func (eds *ExtendedDataSquare) Col(y uint) [][]byte {
 
 // ColRoots returns the Merkle roots of all the columns in the square.
 func (eds *ExtendedDataSquare) ColRoots() [][]byte {
-	return eds.getColRoots()
+	return deepCopy(eds.getColRoots())
 }
 
 // Row returns a row slice.
 // This slice is a copy of the internal row slice.
 func (eds *ExtendedDataSquare) Row(x uint) [][]byte {
-	row := make([][]byte, eds.width)
-	original := eds.row(x)
-	for i, cell := range original {
-		row[i] = make([]byte, eds.chunkSize)
-		copy(row[i], cell)
-	}
-	return row
+	return deepCopy(eds.row(x))
 }
 
 // RowRoots returns the Merkle roots of all the rows in the square.
 func (eds *ExtendedDataSquare) RowRoots() [][]byte {
-	return eds.getRowRoots()
+	return deepCopy(eds.getRowRoots())
+}
+
+func deepCopy(original [][]byte) [][]byte {
+	dest := make([][]byte, len(original))
+	for i, cell := range original {
+		dest[i] = make([]byte, len(cell))
+		copy(dest[i], cell)
+	}
+	return dest
 }
 
 // Width returns the width of the square.

--- a/extendeddatasquare_test.go
+++ b/extendeddatasquare_test.go
@@ -26,6 +26,29 @@ func TestComputeExtendedDataSquare(t *testing.T) {
 	}
 }
 
+func TestEDSRowColImmutable(t *testing.T) {
+	codec := NewRSGF8Codec()
+	result, err := ComputeExtendedDataSquare([][]byte{
+		{1}, {2},
+		{3}, {4},
+	}, codec, NewDefaultTree)
+	if err != nil {
+		panic(err)
+	}
+
+	row := result.Row(0)
+	row[0][0]++
+	if reflect.DeepEqual(row, result.Row(0)) {
+		t.Errorf("Exported EDS Row was mutable")
+	}
+
+	col := result.Col(0)
+	col[0][0]++
+	if reflect.DeepEqual(col, result.Col(0)) {
+		t.Errorf("Exported EDS Col was mutable")
+	}
+}
+
 // dump acts as a data dump for the benchmarks to stop the compiler from making
 // unrealistic optimizations
 var dump *ExtendedDataSquare

--- a/extendeddatasquare_test.go
+++ b/extendeddatasquare_test.go
@@ -26,6 +26,29 @@ func TestComputeExtendedDataSquare(t *testing.T) {
 	}
 }
 
+func TestImmutableRoots(t *testing.T) {
+	codec := NewRSGF8Codec()
+	result, err := ComputeExtendedDataSquare([][]byte{
+		{1}, {2},
+		{3}, {4},
+	}, codec, NewDefaultTree)
+	if err != nil {
+		panic(err)
+	}
+
+	row := result.RowRoots()
+	row[0][0]++
+	if reflect.DeepEqual(row, result.RowRoots()) {
+		t.Errorf("Exported EDS RowRoots was mutable")
+	}
+
+	col := result.ColRoots()
+	col[0][0]++
+	if reflect.DeepEqual(col, result.ColRoots()) {
+		t.Errorf("Exported EDS ColRoots was mutable")
+	}
+}
+
 func TestEDSRowColImmutable(t *testing.T) {
 	codec := NewRSGF8Codec()
 	result, err := ComputeExtendedDataSquare([][]byte{


### PR DESCRIPTION
Closes #101. A bit overkill I guess, but doesn't hurt to have them?

@adlerjohn, Should `eds.RowRoots` and `eds.ColRoots` also return copies? If so I would add a test for those still!