### PR TITLE
Upgrade to Go 1.18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: "1.17"
+          go-version: "1.18"
       - uses: actions/checkout@v2
       - uses: technote-space/get-diff-action@v4
         with:
@@ -45,4 +45,3 @@ jobs:
         with:
           file: ./coverage.txt
         if: env.GIT_DIFF
-

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/celestiaorg/rsmt2d
 
-go 1.17
+go 1.18
 
 require (
 	// only needed if built with go build -tags leopard


### PR DESCRIPTION
Closes https://github.com/celestiaorg/rsmt2d/issues/105

~~Draft PR until I verify that it's safe to consume a Go 1.18 module from a 1.17 app~~ See https://github.com/celestiaorg/rsmt2d/issues/105#issuecomment-1183957521