### PR TITLE
Crossword repair loop fixes

### DIFF
--- a/extendeddatacrossword.go
+++ b/extendeddatacrossword.go
@@ -145,7 +145,11 @@ func (eds *ExtendedDataSquare) solveCrosswordRow(
 	// Check that newly completed orthogonal vectors match their new merkle roots
 	for c := 0; c < int(eds.width); c++ {
 		col := eds.col(uint(c))
-		if noMissingData(col) {
+		if col[r] != nil {
+			continue // not newly completed
+		}
+		col[r] = rebuiltShares[c]
+		if noMissingData(col) { // not completed
 			err := eds.verifyAgainstColRoots(colRoots, uint(c), col)
 			if err != nil {
 				return false, false, err
@@ -203,7 +207,11 @@ func (eds *ExtendedDataSquare) solveCrosswordCol(
 	// Check that newly completed orthogonal vectors match their new merkle roots
 	for r := 0; r < int(eds.width); r++ {
 		row := eds.row(uint(r))
-		if noMissingData(row) {
+		if row[c] != nil {
+			continue // not newly completed
+		}
+		row[c] = rebuiltShares[r]
+		if noMissingData(row) { // completed
 			err := eds.verifyAgainstRowRoots(rowRoots, uint(r), row)
 			if err != nil {
 				return false, false, err

--- a/extendeddatacrossword.go
+++ b/extendeddatacrossword.go
@@ -211,7 +211,7 @@ func (eds *ExtendedDataSquare) solveCrosswordCol(
 			continue // not newly completed
 		}
 		row[c] = rebuiltShares[r]
-		if noMissingData(row) { // completed
+		if noMissingData(row) { // not completed
 			err := eds.verifyAgainstRowRoots(rowRoots, uint(r), row)
 			if err != nil {
 				return false, false, err


### PR DESCRIPTION
- [x] Fix #113
- [x] Fix #109

Before:
```
goos: linux
goarch: amd64
pkg: github.com/celestiaorg/rsmt2d
cpu: 11th Gen Intel(R) Core(TM) i9-11900H @ 2.50GHz
BenchmarkRepair/Repairing_16x16_ODS_using_RSGF8-16         	      33	  36366217 ns/op
BenchmarkRepair/Repairing_32x32_ODS_using_RSGF8-16         	       4	 291625597 ns/op
BenchmarkRepair/Repairing_64x64_ODS_using_RSGF8-16         	       1	2196795856 ns/op
BenchmarkRepair/Repairing_128x128_ODS_using_RSGF8-16       	       1	18349927611 ns/op
```

After:
```
goos: linux
goarch: amd64
pkg: github.com/celestiaorg/rsmt2d
cpu: 11th Gen Intel(R) Core(TM) i9-11900H @ 2.50GHz
BenchmarkRepair/Repairing_16x16_ODS_using_RSGF8-16         	     363	   3733920 ns/op
BenchmarkRepair/Repairing_32x32_ODS_using_RSGF8-16         	      82	  20524141 ns/op
BenchmarkRepair/Repairing_64x64_ODS_using_RSGF8-16         	      16	  64611698 ns/op
BenchmarkRepair/Repairing_128x128_ODS_using_RSGF8-16       	       4	 268046116 ns/op
```