### PR TITLE
Benchmark the root generation when benchmarking extension.

### DIFF
--- a/extendeddatasquare_test.go
+++ b/extendeddatasquare_test.go
@@ -89,6 +89,8 @@ func BenchmarkExtension(b *testing.B) {
 						if err != nil {
 							b.Error(err)
 						}
+						_ = eds.RowRoots()
+						_ = eds.ColRoots()
 						dump = eds
 					}
 				},


### PR DESCRIPTION
This results in more accurate extension benchmarking, computing the Merkle roots is a significant overhead.