### PR TITLE
Parallelise data extension and pre-repair sanity check

### DIFF
--- a/datasquare.go
+++ b/datasquare.go
@@ -221,7 +221,7 @@ func (ds *dataSquare) getRowRoot(x uint) []byte {
 		return ds.rowRoots[x]
 	}
 
-	tree := ds.createTreeFn()
+	tree := ds.createTreeFn(Row, x)
 	for i, d := range ds.row(x) {
 		tree.Push(d, SquareIndex{Cell: uint(i), Axis: x})
 	}
@@ -245,7 +245,7 @@ func (ds *dataSquare) getColRoot(y uint) []byte {
 		return ds.colRoots[y]
 	}
 
-	tree := ds.createTreeFn()
+	tree := ds.createTreeFn(Col, y)
 	for i, d := range ds.col(y) {
 		tree.Push(d, SquareIndex{Axis: y, Cell: uint(i)})
 	}

--- a/datasquare.go
+++ b/datasquare.go
@@ -215,7 +215,7 @@ func (ds *dataSquare) getRowRoots() [][]byte {
 }
 
 // getRowRoot calculates and returns the root of the selected row. Note: unlike the
-// getRowRoots method, getRowRoot uses the built-in cache when available.
+// getRowRoots method, getRowRoot does not write to the built-in cache.
 func (ds *dataSquare) getRowRoot(x uint) []byte {
 	if ds.rowRoots != nil {
 		return ds.rowRoots[x]
@@ -239,7 +239,7 @@ func (ds *dataSquare) getColRoots() [][]byte {
 }
 
 // getColRoot calculates and returns the root of the selected row. Note: unlike the
-// getColRoots method, getColRoot uses the built-in cache when available.
+// getColRoots method, getColRoot does not write to the built-in cache.
 func (ds *dataSquare) getColRoot(y uint) []byte {
 	if ds.colRoots != nil {
 		return ds.colRoots[y]

--- a/datasquare.go
+++ b/datasquare.go
@@ -182,7 +182,6 @@ func (ds *dataSquare) resetRoots() {
 
 func (ds *dataSquare) computeRoots() {
 	var wg sync.WaitGroup
-	var mu sync.Mutex
 
 	rowRoots := make([][]byte, ds.width)
 	colRoots := make([][]byte, ds.width)
@@ -194,21 +193,13 @@ func (ds *dataSquare) computeRoots() {
 		go func() {
 			defer wg.Done()
 
-			rowRoot := ds.getRowRoot(i)
-
-			mu.Lock()
-			defer mu.Unlock()
-			rowRoots[i] = rowRoot
+			rowRoots[i] = ds.getRowRoot(i)
 		}()
 
 		go func() {
 			defer wg.Done()
 
-			colRoot := ds.getColRoot(i)
-
-			mu.Lock()
-			defer mu.Unlock()
-			colRoots[i] = colRoot
+			colRoots[i] = ds.getColRoot(i)
 		}()
 	}
 

--- a/datasquare.go
+++ b/datasquare.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"sync"
 )
 
 // ErrUnevenChunks is thrown when non-nil chunks are not all of equal size.
@@ -15,6 +16,7 @@ var ErrUnevenChunks = errors.New("non-nil chunks not all of equal size")
 type dataSquare struct {
 	squareRow    [][][]byte // row-major
 	squareCol    [][][]byte // col-major
+	dataMutex    sync.Mutex
 	width        uint
 	chunkSize    uint
 	rowRoots     [][]byte
@@ -130,6 +132,9 @@ func (ds *dataSquare) setRowSlice(x uint, y uint, newRow [][]byte) error {
 		}
 	}
 
+	ds.dataMutex.Lock()
+	defer ds.dataMutex.Unlock()
+
 	for i := uint(0); i < uint(len(newRow)); i++ {
 		ds.squareRow[x][y+i] = newRow[i]
 		ds.squareCol[y+i][x] = newRow[i]
@@ -156,6 +161,9 @@ func (ds *dataSquare) setColSlice(x uint, y uint, newCol [][]byte) error {
 			return errors.New("invalid chunk size")
 		}
 	}
+
+	ds.dataMutex.Lock()
+	defer ds.dataMutex.Unlock()
 
 	for i := uint(0); i < uint(len(newCol)); i++ {
 		ds.squareRow[x+i][y] = newCol[i]

--- a/datasquare.go
+++ b/datasquare.go
@@ -187,20 +187,17 @@ func (ds *dataSquare) computeRoots() {
 	colRoots := make([][]byte, ds.width)
 
 	for i := uint(0); i < ds.width; i++ {
-		i := i
 		wg.Add(2)
 
-		go func() {
+		go func(i uint) {
 			defer wg.Done()
-
 			rowRoots[i] = ds.getRowRoot(i)
-		}()
+		}(i)
 
-		go func() {
+		go func(i uint) {
 			defer wg.Done()
-
 			colRoots[i] = ds.getColRoot(i)
-		}()
+		}(i)
 	}
 
 	wg.Wait()

--- a/datasquare_test.go
+++ b/datasquare_test.go
@@ -214,7 +214,7 @@ func BenchmarkRoots(b *testing.B) {
 }
 
 func computeRowProof(ds *dataSquare, x uint, y uint) ([]byte, [][]byte, uint, uint, error) {
-	tree := ds.createTreeFn()
+	tree := ds.createTreeFn(Row, x)
 	data := ds.row(x)
 
 	for i := uint(0); i < ds.width; i++ {
@@ -226,7 +226,7 @@ func computeRowProof(ds *dataSquare, x uint, y uint) ([]byte, [][]byte, uint, ui
 }
 
 func computeColProof(ds *dataSquare, x uint, y uint) ([]byte, [][]byte, uint, uint, error) {
-	tree := ds.createTreeFn()
+	tree := ds.createTreeFn(Col, y)
 	data := ds.col(y)
 
 	for i := uint(0); i < ds.width; i++ {

--- a/extendeddatacrossword.go
+++ b/extendeddatacrossword.go
@@ -2,8 +2,11 @@ package rsmt2d
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
+
+	"golang.org/x/sync/errgroup"
 )
 
 // Axis represents which of a row or col.
@@ -296,48 +299,63 @@ func (eds *ExtendedDataSquare) prerepairSanityCheck(
 	rowRoots [][]byte,
 	colRoots [][]byte,
 ) error {
+	errs, _ := errgroup.WithContext(context.Background())
+
 	for i := uint(0); i < eds.width; i++ {
+		i := i
 		rowIsComplete := noMissingData(eds.row(i))
 		colIsComplete := noMissingData(eds.col(i))
 
 		// if there's no missing data in the this row
 		if rowIsComplete {
-			// ensure that the roots are equal and that rowMask is a vector
-			if !bytes.Equal(rowRoots[i], eds.getRowRoot(i)) {
-				return fmt.Errorf("bad root input: row %d expected %v got %v", i, rowRoots[i], eds.getRowRoot(i))
-			}
+			errs.Go(func() error {
+				// ensure that the roots are equal
+				if !bytes.Equal(rowRoots[i], eds.getRowRoot(i)) {
+					return fmt.Errorf("bad root input: row %d expected %v got %v", i, rowRoots[i], eds.getRowRoot(i))
+				}
+				return nil
+			})
 		}
 
 		// if there's no missing data in the this col
 		if colIsComplete {
-			// ensure that the roots are equal and that rowMask is a vector
-			if !bytes.Equal(colRoots[i], eds.getColRoot(i)) {
-				return fmt.Errorf("bad root input: col %d expected %v got %v", i, colRoots[i], eds.getColRoot(i))
-			}
+			errs.Go(func() error {
+				// ensure that the roots are equal
+				if !bytes.Equal(colRoots[i], eds.getColRoot(i)) {
+					return fmt.Errorf("bad root input: col %d expected %v got %v", i, colRoots[i], eds.getColRoot(i))
+				}
+				return nil
+			})
 		}
 
 		if rowIsComplete {
-			parityShares, err := eds.codec.Encode(eds.rowSlice(i, 0, eds.originalDataWidth))
-			if err != nil {
-				return err
-			}
-			if !bytes.Equal(flattenChunks(parityShares), flattenChunks(eds.rowSlice(i, eds.originalDataWidth, eds.originalDataWidth))) {
-				return &ErrByzantineData{Row, i, eds.row(i)}
-			}
+			errs.Go(func() error {
+				parityShares, err := eds.codec.Encode(eds.rowSlice(i, 0, eds.originalDataWidth))
+				if err != nil {
+					return err
+				}
+				if !bytes.Equal(flattenChunks(parityShares), flattenChunks(eds.rowSlice(i, eds.originalDataWidth, eds.originalDataWidth))) {
+					return &ErrByzantineData{Row, i, eds.row(i)}
+				}
+				return nil
+			})
 		}
 
 		if colIsComplete {
-			parityShares, err := eds.codec.Encode(eds.colSlice(0, i, eds.originalDataWidth))
-			if err != nil {
-				return err
-			}
-			if !bytes.Equal(flattenChunks(parityShares), flattenChunks(eds.colSlice(eds.originalDataWidth, i, eds.originalDataWidth))) {
-				return &ErrByzantineData{Col, i, eds.col(i)}
-			}
+			errs.Go(func() error {
+				parityShares, err := eds.codec.Encode(eds.colSlice(0, i, eds.originalDataWidth))
+				if err != nil {
+					return err
+				}
+				if !bytes.Equal(flattenChunks(parityShares), flattenChunks(eds.colSlice(eds.originalDataWidth, i, eds.originalDataWidth))) {
+					return &ErrByzantineData{Col, i, eds.col(i)}
+				}
+				return nil
+			})
 		}
 	}
 
-	return nil
+	return errs.Wait()
 }
 
 func noMissingData(input [][]byte) bool {

--- a/extendeddatacrossword.go
+++ b/extendeddatacrossword.go
@@ -269,7 +269,7 @@ func (eds *ExtendedDataSquare) verifyAgainstRowRoots(
 	r uint,
 	shares [][]byte,
 ) error {
-	root := eds.computeSharesRoot(shares, r)
+	root := eds.computeSharesRoot(shares, Row, r)
 
 	if !bytes.Equal(root, rowRoots[r]) {
 		return &ErrByzantineData{Row, r, shares}
@@ -283,7 +283,7 @@ func (eds *ExtendedDataSquare) verifyAgainstColRoots(
 	c uint,
 	shares [][]byte,
 ) error {
-	root := eds.computeSharesRoot(shares, c)
+	root := eds.computeSharesRoot(shares, Col, c)
 
 	if !bytes.Equal(root, colRoots[c]) {
 		return &ErrByzantineData{Col, c, shares}
@@ -349,8 +349,8 @@ func noMissingData(input [][]byte) bool {
 	return true
 }
 
-func (eds *ExtendedDataSquare) computeSharesRoot(shares [][]byte, i uint) []byte {
-	tree := eds.createTreeFn()
+func (eds *ExtendedDataSquare) computeSharesRoot(shares [][]byte, axis Axis, i uint) []byte {
+	tree := eds.createTreeFn(axis, i)
 	for cell, d := range shares {
 		tree.Push(d, SquareIndex{Cell: uint(cell), Axis: i})
 	}

--- a/extendeddatacrossword.go
+++ b/extendeddatacrossword.go
@@ -101,6 +101,10 @@ func (eds *ExtendedDataSquare) solveCrossword(
 		}
 	}
 
+	// Update roots of solved eds
+	eds.rowRoots = rowRoots
+	eds.colRoots = colRoots
+
 	return nil
 }
 

--- a/extendeddatacrossword.go
+++ b/extendeddatacrossword.go
@@ -104,10 +104,6 @@ func (eds *ExtendedDataSquare) solveCrossword(
 		}
 	}
 
-	// Update roots of solved eds
-	eds.rowRoots = rowRoots
-	eds.colRoots = colRoots
-
 	return nil
 }
 

--- a/extendeddatacrossword_test.go
+++ b/extendeddatacrossword_test.go
@@ -95,8 +95,9 @@ func TestRepairExtendedDataSquare(t *testing.T) {
 		corrupted.setCell(0, 0, corruptChunk)
 		err = corrupted.Repair(corrupted.getRowRoots(), corrupted.getColRoots())
 		var byzData *ErrByzantineData
-		if !errors.As(err, &byzData) || byzData.Axis != Row {
-			t.Errorf("did not return a ErrByzantineData for a bad row; got: %v", err)
+		if !errors.As(err, &byzData) {
+			// due to parallelisation, the ErrByzantineData axis may be either row or col
+			t.Errorf("did not return a ErrByzantineData for a bad row or col; got: %v", err)
 		}
 		// Construct the fraud proof
 		fraudProof := PseudoFraudProof{0, byzData.Index, byzData.Shares}
@@ -125,8 +126,9 @@ func TestRepairExtendedDataSquare(t *testing.T) {
 		}
 		corrupted.setCell(0, 3, corruptChunk)
 		err = corrupted.Repair(corrupted.getRowRoots(), corrupted.getColRoots())
-		if !errors.As(err, &byzData) || byzData.Axis != Row {
-			t.Errorf("did not return a ErrByzantineData for a bad row; got %v", err)
+		if !errors.As(err, &byzData) {
+			// due to parallelisation, the ErrByzantineData axis may be either row or col
+			t.Errorf("did not return a ErrByzantineData for a bad row or col; got %v", err)
 		}
 
 		corrupted, err = original.deepCopy(codec)
@@ -150,8 +152,9 @@ func TestRepairExtendedDataSquare(t *testing.T) {
 		corrupted.setCell(0, 2, nil)
 		corrupted.setCell(0, 3, nil)
 		err = corrupted.Repair(corrupted.getRowRoots(), corrupted.getColRoots())
-		if !errors.As(err, &byzData) || byzData.Axis != Col {
-			t.Errorf("did not return a ErrByzantineData for a bad column; got %v", err)
+		if !errors.As(err, &byzData) {
+			// due to parallelisation, the ErrByzantineData axis may be either row or col
+			t.Errorf("did not return a ErrByzantineData for a bad col or row; got %v", err)
 		}
 	}
 }

--- a/extendeddatacrossword_test.go
+++ b/extendeddatacrossword_test.go
@@ -106,7 +106,7 @@ func TestRepairExtendedDataSquare(t *testing.T) {
 		if err != nil {
 			t.Errorf("could not decode fraud proof shares; got: %v", err)
 		}
-		root := corrupted.computeSharesRoot(rebuiltShares, fraudProof.Index)
+		root := corrupted.computeSharesRoot(rebuiltShares, byzData.Axis, fraudProof.Index)
 		if bytes.Equal(root, corrupted.getRowRoot(fraudProof.Index)) {
 			// If the roots match, then the fraud proof should be for invalid erasure coding.
 			parityShares, err := codec.Encode(rebuiltShares[0:corrupted.originalDataWidth])

--- a/extendeddatasquare.go
+++ b/extendeddatasquare.go
@@ -84,19 +84,21 @@ func (eds *ExtendedDataSquare) erasureExtendSquare(codec Codec) error {
 	// |       |
 	//  -------
 	for i := uint(0); i < eds.originalDataWidth; i++ {
+		iArg := i
+
 		// Extend horizontally
 		errs.Go(func() error {
-			return eds.erasureExtendRow(codec, i)
+			return eds.erasureExtendRow(codec, iArg)
 		})
 
 		// Extend vertically
 		errs.Go(func() error {
-			return eds.erasureExtendCol(codec, i)
+			return eds.erasureExtendCol(codec, iArg)
 		})
+	}
 
-		if err := errs.Wait(); err != nil {
-			return err
-		}
+	if err := errs.Wait(); err != nil {
+		return err
 	}
 
 	// Extend extended square horizontally
@@ -110,14 +112,16 @@ func (eds *ExtendedDataSquare) erasureExtendSquare(codec Codec) error {
 	// |       |       |
 	//  ------- -------
 	for i := eds.originalDataWidth; i < eds.width; i++ {
+		iArg := i
+
 		// Extend horizontally
 		errs.Go(func() error {
-			return eds.erasureExtendRow(codec, i)
+			return eds.erasureExtendRow(codec, iArg)
 		})
+	}
 
-		if err := errs.Wait(); err != nil {
-			return err
-		}
+	if err := errs.Wait(); err != nil {
+		return err
 	}
 
 	return nil

--- a/extendeddatasquare.go
+++ b/extendeddatasquare.go
@@ -120,11 +120,7 @@ func (eds *ExtendedDataSquare) erasureExtendSquare(codec Codec) error {
 		})
 	}
 
-	if err := errs.Wait(); err != nil {
-		return err
-	}
-
-	return nil
+	return errs.Wait()
 }
 
 func (eds *ExtendedDataSquare) erasureExtendRow(codec Codec, i uint) error {

--- a/extendeddatasquare.go
+++ b/extendeddatasquare.go
@@ -68,7 +68,6 @@ func (eds *ExtendedDataSquare) erasureExtendSquare(codec Codec) error {
 		return err
 	}
 
-	var shares [][]byte
 	var err error
 
 	// Extend original square horizontally and vertically
@@ -83,20 +82,14 @@ func (eds *ExtendedDataSquare) erasureExtendSquare(codec Codec) error {
 	//  -------
 	for i := uint(0); i < eds.originalDataWidth; i++ {
 		// Extend horizontally
-		shares, err = codec.Encode(eds.rowSlice(i, 0, eds.originalDataWidth))
+		err = eds.erasureExtendRow(codec, i)
 		if err != nil {
-			return err
-		}
-		if err := eds.setRowSlice(i, eds.originalDataWidth, shares[len(shares)-int(eds.originalDataWidth):]); err != nil {
 			return err
 		}
 
 		// Extend vertically
-		shares, err = codec.Encode(eds.colSlice(0, i, eds.originalDataWidth))
+		err = eds.erasureExtendCol(codec, i)
 		if err != nil {
-			return err
-		}
-		if err := eds.setColSlice(eds.originalDataWidth, i, shares[len(shares)-int(eds.originalDataWidth):]); err != nil {
 			return err
 		}
 	}
@@ -113,15 +106,40 @@ func (eds *ExtendedDataSquare) erasureExtendSquare(codec Codec) error {
 	//  ------- -------
 	for i := eds.originalDataWidth; i < eds.width; i++ {
 		// Extend horizontally
-		shares, err = codec.Encode(eds.rowSlice(i, 0, eds.originalDataWidth))
+		err = eds.erasureExtendRow(codec, i)
 		if err != nil {
-			return err
-		}
-		if err := eds.setRowSlice(i, eds.originalDataWidth, shares[len(shares)-int(eds.originalDataWidth):]); err != nil {
 			return err
 		}
 	}
 
+	return nil
+}
+
+func (eds *ExtendedDataSquare) erasureExtendRow(codec Codec, i uint) error {
+	var shares [][]byte
+	var err error
+
+	shares, err = codec.Encode(eds.rowSlice(i, 0, eds.originalDataWidth))
+	if err != nil {
+		return err
+	}
+	if err := eds.setRowSlice(i, eds.originalDataWidth, shares[len(shares)-int(eds.originalDataWidth):]); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (eds *ExtendedDataSquare) erasureExtendCol(codec Codec, i uint) error {
+	var shares [][]byte
+	var err error
+
+	shares, err = codec.Encode(eds.colSlice(0, i, eds.originalDataWidth))
+	if err != nil {
+		return err
+	}
+	if err := eds.setColSlice(eds.originalDataWidth, i, shares[len(shares)-int(eds.originalDataWidth):]); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/extendeddatasquare.go
+++ b/extendeddatasquare.go
@@ -84,16 +84,16 @@ func (eds *ExtendedDataSquare) erasureExtendSquare(codec Codec) error {
 	// |       |
 	//  -------
 	for i := uint(0); i < eds.originalDataWidth; i++ {
-		iArg := i
+		i := i
 
 		// Extend horizontally
 		errs.Go(func() error {
-			return eds.erasureExtendRow(codec, iArg)
+			return eds.erasureExtendRow(codec, i)
 		})
 
 		// Extend vertically
 		errs.Go(func() error {
-			return eds.erasureExtendCol(codec, iArg)
+			return eds.erasureExtendCol(codec, i)
 		})
 	}
 
@@ -112,11 +112,11 @@ func (eds *ExtendedDataSquare) erasureExtendSquare(codec Codec) error {
 	// |       |       |
 	//  ------- -------
 	for i := eds.originalDataWidth; i < eds.width; i++ {
-		iArg := i
+		i := i
 
 		// Extend horizontally
 		errs.Go(func() error {
-			return eds.erasureExtendRow(codec, iArg)
+			return eds.erasureExtendRow(codec, i)
 		})
 	}
 

--- a/extendeddatasquare_test.go
+++ b/extendeddatasquare_test.go
@@ -89,8 +89,8 @@ func BenchmarkExtension(b *testing.B) {
 						if err != nil {
 							b.Error(err)
 						}
-						_ = eds.RowRoots()
-						_ = eds.ColRoots()
+						//_ = eds.RowRoots()
+						//_ = eds.ColRoots()
 						dump = eds
 					}
 				},

--- a/extendeddatasquare_test.go
+++ b/extendeddatasquare_test.go
@@ -89,8 +89,8 @@ func BenchmarkExtension(b *testing.B) {
 						if err != nil {
 							b.Error(err)
 						}
-						//_ = eds.RowRoots()
-						//_ = eds.ColRoots()
+						_ = eds.RowRoots()
+						_ = eds.ColRoots()
 						dump = eds
 					}
 				},

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gitlab.com/NebulousLabs/errors v0.0.0-20200929122200-06c536cf6975 // indirect
 	golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2 // indirect
+	golang.org/x/sync v0.0.0-20220907140024-f12130a52804
 	golang.org/x/sys v0.0.0-20210403161142-5e06dd20ab57 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/kr/text v0.2.0 // indirect
+	github.com/minio/sha256-simd v1.0.0
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gitlab.com/NebulousLabs/errors v0.0.0-20200929122200-06c536cf6975 // indirect
 	golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2 // indirect
@@ -21,3 +22,5 @@ require (
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )
+
+require github.com/klauspost/cpuid/v2 v2.0.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -6,12 +6,16 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/klauspost/cpuid/v2 v2.0.4 h1:g0I61F2K2DjRHz1cnxlkNSBIaePVoJIjjnHui8QHbiw=
+github.com/klauspost/cpuid/v2 v2.0.4/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
 github.com/kr/pretty v0.2.1 h1:Fmg33tUaq4/8ym9TJN1x7sLJnHVwhP33CNkpYV/7rwI=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
+github.com/minio/sha256-simd v1.0.0 h1:v1ta+49hkWZyvaKwrQB8elexRqm6Y0aMLjCNsrYxo6g=
+github.com/minio/sha256-simd v1.0.0/go.mod h1:OuYzVNI5vcoYIAmbIvHPl3N3jUzVedXbKy5RFepssQM=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/go.sum
+++ b/go.sum
@@ -31,6 +31,8 @@ golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2 h1:It14KIkyBFYkHkwZ7k45mi
 golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
+golang.org/x/sync v0.0.0-20220907140024-f12130a52804 h1:0SH2R3f1b1VmIMG7BXbEZCBUu2dKmHschSmjqGUrW8A=
+golang.org/x/sync v0.0.0-20220907140024-f12130a52804/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/tree.go
+++ b/tree.go
@@ -7,7 +7,7 @@ import (
 )
 
 // TreeConstructorFn creates a fresh Tree instance to be used as the Merkle inside of rsmt2d.
-type TreeConstructorFn = func() Tree
+type TreeConstructorFn = func(axis Axis, index uint) Tree
 
 // SquareIndex contains all information needed to identify the cell that is being
 // pushed
@@ -29,7 +29,7 @@ type DefaultTree struct {
 	root   []byte
 }
 
-func NewDefaultTree() Tree {
+func NewDefaultTree(axis Axis, index uint) Tree {
 	return &DefaultTree{
 		Tree:   merkletree.New(sha256.New()),
 		leaves: make([][]byte, 0, 128),

--- a/tree.go
+++ b/tree.go
@@ -1,7 +1,7 @@
 package rsmt2d
 
 import (
-	"crypto/sha256"
+	"github.com/minio/sha256-simd"
 
 	"github.com/celestiaorg/merkletree"
 )


### PR DESCRIPTION
Notes:
- although we implement some mutexes in dataSquare, we do not claim that dataSquare itself is now thread-safe, as we only added the minimal number of locks to make parallel extension work.
- in all the following benchmarks, extension has been benchmarks without computing the row and column roots, which continues to be the primary bottleneck.
- `cpu: 11th Gen Intel(R) Core(TM) i9-11900H @ 2.50GHz`

go-leopard + parallelisation
```
BenchmarkExtension/LeopardFF8_size_4-16         	   21063	     58295 ns/op
BenchmarkExtension/LeopardFF16_size_4-16        	   20356	     60095 ns/op
BenchmarkExtension/RSGF8_size_4-16              	   46251	     25855 ns/op
BenchmarkExtension/RSGF8_size_8-16              	   16380	     73586 ns/op
BenchmarkExtension/LeopardFF8_size_8-16         	    8278	    145906 ns/op
BenchmarkExtension/LeopardFF16_size_8-16        	    8599	    145683 ns/op
BenchmarkExtension/RSGF8_size_16-16             	    5766	    211363 ns/op
BenchmarkExtension/LeopardFF8_size_16-16        	    2546	    413941 ns/op
BenchmarkExtension/LeopardFF16_size_16-16       	    2623	    396130 ns/op
BenchmarkExtension/RSGF8_size_32-16             	    1718	    742880 ns/op
BenchmarkExtension/LeopardFF8_size_32-16        	     949	   1280569 ns/op
BenchmarkExtension/LeopardFF16_size_32-16       	     910	   1330538 ns/op
BenchmarkExtension/RSGF8_size_64-16             	     416	   2743251 ns/op
BenchmarkExtension/LeopardFF8_size_64-16        	     384	   3193578 ns/op
BenchmarkExtension/LeopardFF16_size_64-16       	     381	   3094233 ns/op
BenchmarkExtension/RSGF8_size_128-16            	      88	  13574625 ns/op
BenchmarkExtension/LeopardFF8_size_128-16       	     100	  10233559 ns/op
BenchmarkExtension/LeopardFF16_size_128-16      	     100	  10620378 ns/op
```

go-leopard + no parallelisation
```
goos: linux
goarch: amd64
pkg: github.com/celestiaorg/rsmt2d
cpu: 11th Gen Intel(R) Core(TM) i9-11900H @ 2.50GHz
BenchmarkExtension/RSGF8_size_4-16         	  117916	     11580 ns/op
BenchmarkExtension/LeopardFF8_size_4-16    	   15774	     92830 ns/op
BenchmarkExtension/LeopardFF16_size_4-16   	   15693	     90473 ns/op
BenchmarkExtension/RSGF8_size_8-16         	   28026	     58276 ns/op
BenchmarkExtension/LeopardFF8_size_8-16    	    6709	    282830 ns/op
BenchmarkExtension/LeopardFF16_size_8-16   	    6716	    203269 ns/op
BenchmarkExtension/RSGF8_size_16-16        	    4826	    347929 ns/op
BenchmarkExtension/LeopardFF8_size_16-16   	    1660	    965310 ns/op
BenchmarkExtension/LeopardFF16_size_16-16  	    1723	   1063590 ns/op
BenchmarkExtension/LeopardFF8_size_32-16   	     378	   5191836 ns/op
BenchmarkExtension/LeopardFF16_size_32-16  	     336	   4367580 ns/op
BenchmarkExtension/RSGF8_size_32-16        	     625	   2098900 ns/op
BenchmarkExtension/RSGF8_size_64-16        	     103	  11749111 ns/op
BenchmarkExtension/LeopardFF8_size_64-16   	      93	  12668505 ns/op
BenchmarkExtension/LeopardFF16_size_64-16  	     100	  13156762 ns/op
BenchmarkExtension/RSGF8_size_128-16       	      15	  71221686 ns/op
BenchmarkExtension/LeopardFF8_size_128-16  	      25	  44580184 ns/op
BenchmarkExtension/LeopardFF16_size_128-16 	      25	  43923193 ns/op
```

klauspost + parallelisation
```
goos: linux
goarch: amd64
pkg: github.com/celestiaorg/rsmt2d
cpu: 11th Gen Intel(R) Core(TM) i9-11900H @ 2.50GHz
BenchmarkExtension/RSGF8_size_4-16         	   62449	     18151 ns/op
BenchmarkExtension/LeopardFF8_size_4-16    	   37773	     31655 ns/op
BenchmarkExtension/LeopardFF16_size_4-16   	   37440	     32032 ns/op
BenchmarkExtension/LeopardFF16_size_8-16   	   20168	     57223 ns/op
BenchmarkExtension/RSGF8_size_8-16         	   25146	     46824 ns/op
BenchmarkExtension/LeopardFF8_size_8-16    	   20571	     57741 ns/op
BenchmarkExtension/RSGF8_size_16-16        	   10000	    116269 ns/op
BenchmarkExtension/LeopardFF8_size_16-16   	   10000	    104035 ns/op
BenchmarkExtension/LeopardFF16_size_16-16  	   10000	    102806 ns/op
BenchmarkExtension/RSGF8_size_32-16        	    2890	    394711 ns/op
BenchmarkExtension/LeopardFF8_size_32-16   	    4833	    255505 ns/op
BenchmarkExtension/LeopardFF16_size_32-16  	    4370	    253097 ns/op
BenchmarkExtension/RSGF8_size_64-16        	     610	   2031755 ns/op
BenchmarkExtension/LeopardFF8_size_64-16   	    1654	    692710 ns/op
BenchmarkExtension/LeopardFF16_size_64-16  	    1682	    706555 ns/op
BenchmarkExtension/LeopardFF8_size_128-16  	     450	   2744351 ns/op
BenchmarkExtension/LeopardFF16_size_128-16 	     418	   2755398 ns/op
BenchmarkExtension/RSGF8_size_128-16       	      87	  13653183 ns/op
```

klauspost + no parallelisation
```
goos: linux
goarch: amd64
pkg: github.com/celestiaorg/rsmt2d
cpu: 11th Gen Intel(R) Core(TM) i9-11900H @ 2.50GHz
BenchmarkExtension/RSGF8_size_4-16         	  135792	      8126 ns/op
BenchmarkExtension/LeopardFF8_size_4-16    	  172027	      6770 ns/op
BenchmarkExtension/LeopardFF16_size_4-16   	  166657	      6446 ns/op
BenchmarkExtension/LeopardFF8_size_8-16    	   50572	     23574 ns/op
BenchmarkExtension/LeopardFF16_size_8-16   	   45315	     23324 ns/op
BenchmarkExtension/RSGF8_size_8-16         	   33289	     34886 ns/op
BenchmarkExtension/RSGF8_size_16-16        	    5365	    202124 ns/op
BenchmarkExtension/LeopardFF8_size_16-16   	   13940	     87224 ns/op
BenchmarkExtension/LeopardFF16_size_16-16  	   13310	     87464 ns/op
BenchmarkExtension/RSGF8_size_32-16        	     831	   1344954 ns/op
BenchmarkExtension/LeopardFF8_size_32-16   	    3138	    384758 ns/op
BenchmarkExtension/LeopardFF16_size_32-16  	    2631	    390911 ns/op
BenchmarkExtension/LeopardFF16_size_64-16  	     705	   1656914 ns/op
BenchmarkExtension/RSGF8_size_64-16        	     124	   9772882 ns/op
BenchmarkExtension/LeopardFF8_size_64-16   	     687	   1618216 ns/op
BenchmarkExtension/RSGF8_size_128-16       	      15	  72573958 ns/op
BenchmarkExtension/LeopardFF8_size_128-16  	     152	   7759006 ns/op
BenchmarkExtension/LeopardFF16_size_128-16 	     152	   7793278 ns/op
```