### PR TITLE
Revamp benchmarks, increase max square size

### DIFF
--- a/codec_test.go
+++ b/codec_test.go
@@ -16,7 +16,7 @@ func BenchmarkEncoding(b *testing.B) {
 	data := generateRandData(128)
 	for codecName, codec := range codecs {
 		b.Run(
-			fmt.Sprintf("Encoding 128 shares using %s", codecName),
+			fmt.Sprintf("%s 128 shares", codecName),
 			func(b *testing.B) {
 				for n := 0; n < b.N; n++ {
 					encodedData, err := codec.Encode(data)
@@ -48,7 +48,7 @@ func BenchmarkDecoding(b *testing.B) {
 	for codecName, codec := range codecs {
 		data := generateMissingData(128, codec)
 		b.Run(
-			fmt.Sprintf("Decoding 128 shares using %s", codecName),
+			fmt.Sprintf("%s 128 shares", codecName),
 			func(b *testing.B) {
 				for n := 0; n < b.N; n++ {
 					encodedData, err := codec.Decode(data)

--- a/datasquare_test.go
+++ b/datasquare_test.go
@@ -203,7 +203,7 @@ func BenchmarkEDSRoots(b *testing.B) {
 			b.Errorf("Failure to create square of size %d: %s", i, err)
 		}
 		b.Run(
-			fmt.Sprintf("%dx%dx256 ODS", i, i),
+			fmt.Sprintf("%dx%dx%d ODS", i, i, int(square.chunkSize)),
 			func(b *testing.B) {
 				for n := 0; n < b.N; n++ {
 					square.resetRoots()

--- a/datasquare_test.go
+++ b/datasquare_test.go
@@ -196,16 +196,17 @@ func TestDefaultTreeProofs(t *testing.T) {
 	}
 }
 
-func BenchmarkRoots(b *testing.B) {
-	for i := 32; i < 257; i *= 2 {
-		square, err := newDataSquare(genRandDS(i), NewDefaultTree)
+func BenchmarkEDSRoots(b *testing.B) {
+	for i := 32; i < 513; i *= 2 {
+		square, err := newDataSquare(genRandDS(i*2), NewDefaultTree)
 		if err != nil {
 			b.Errorf("Failure to create square of size %d: %s", i, err)
 		}
 		b.Run(
-			fmt.Sprintf("Square Size %dx%d", i, i),
+			fmt.Sprintf("%dx%dx256 ODS", i, i),
 			func(b *testing.B) {
 				for n := 0; n < b.N; n++ {
+					square.resetRoots()
 					square.computeRoots()
 				}
 			},

--- a/extendeddatacrossword_test.go
+++ b/extendeddatacrossword_test.go
@@ -158,7 +158,7 @@ func TestRepairExtendedDataSquare(t *testing.T) {
 
 func BenchmarkRepair(b *testing.B) {
 	// For different ODS sizes
-	for originalDataWidth := 16; originalDataWidth <= 512; originalDataWidth *= 2 {
+	for originalDataWidth := 4; originalDataWidth <= 512; originalDataWidth *= 2 {
 		for codecName, codec := range codecs {
 			if codec.maxChunks() < originalDataWidth*originalDataWidth {
 				// Only test codecs that support this many chunks

--- a/extendeddatacrossword_test.go
+++ b/extendeddatacrossword_test.go
@@ -158,8 +158,13 @@ func TestRepairExtendedDataSquare(t *testing.T) {
 
 func BenchmarkRepair(b *testing.B) {
 	// For different ODS sizes
-	for originalDataWidth := 16; originalDataWidth <= 128; originalDataWidth *= 2 {
+	for originalDataWidth := 16; originalDataWidth <= 512; originalDataWidth *= 2 {
 		for codecName, codec := range codecs {
+			if codec.maxChunks() < originalDataWidth*originalDataWidth {
+				// Only test codecs that support this many chunks
+				continue
+			}
+
 			// Generate a new range original data square then extend it
 			square := genRandDS(originalDataWidth)
 			eds, err := ComputeExtendedDataSquare(square, codec, NewDefaultTree)
@@ -173,10 +178,11 @@ func BenchmarkRepair(b *testing.B) {
 
 			b.Run(
 				fmt.Sprintf(
-					"Repairing %dx%d ODS using %s",
-					originalDataWidth,
-					originalDataWidth,
+					"%s %dx%dx%d ODS",
 					codecName,
+					originalDataWidth,
+					originalDataWidth,
+					len(square[0]),
 				),
 				func(b *testing.B) {
 					for n := 0; n < b.N; n++ {

--- a/extendeddatasquare_test.go
+++ b/extendeddatasquare_test.go
@@ -77,12 +77,44 @@ func TestEDSRowColImmutable(t *testing.T) {
 var dump *ExtendedDataSquare
 
 // BenchmarkExtension benchmarks extending datasquares sizes 4-128 using all supported codecs
-func BenchmarkExtension(b *testing.B) {
-	for i := 4; i < 129; i *= 2 {
+func BenchmarkExtensionEncoding(b *testing.B) {
+	for i := 4; i < 513; i *= 2 {
 		for codecName, codec := range codecs {
+			if codec.maxChunks() < i*i {
+				// Only test codecs that support this many chunks
+				continue
+			}
+
 			square := genRandDS(i)
 			b.Run(
-				fmt.Sprintf("%s size %d", codecName, i),
+				fmt.Sprintf("%s %dx%dx%d ODS", codecName, i, i, len(square[0])),
+				func(b *testing.B) {
+					for n := 0; n < b.N; n++ {
+						eds, err := ComputeExtendedDataSquare(square, codec, NewDefaultTree)
+						if err != nil {
+							b.Error(err)
+						}
+						dump = eds
+					}
+				},
+			)
+		}
+
+	}
+}
+
+// BenchmarkExtension benchmarks extending datasquares sizes 4-128 using all supported codecs
+func BenchmarkExtensionWithRoots(b *testing.B) {
+	for i := 4; i < 513; i *= 2 {
+		for codecName, codec := range codecs {
+			if codec.maxChunks() < i*i {
+				// Only test codecs that support this many chunks
+				continue
+			}
+
+			square := genRandDS(i)
+			b.Run(
+				fmt.Sprintf("%s %dx%dx%d ODS", codecName, i, i, len(square[0])),
 				func(b *testing.B) {
 					for n := 0; n < b.N; n++ {
 						eds, err := ComputeExtendedDataSquare(square, codec, NewDefaultTree)

--- a/extendeddatasquare_test.go
+++ b/extendeddatasquare_test.go
@@ -76,7 +76,8 @@ func TestEDSRowColImmutable(t *testing.T) {
 // unrealistic optimizations
 var dump *ExtendedDataSquare
 
-// BenchmarkExtension benchmarks extending datasquares sizes 4-128 using all supported codecs
+// BenchmarkExtension benchmarks extending datasquares sizes 4-128 using all
+// supported codecs (encoding only)
 func BenchmarkExtensionEncoding(b *testing.B) {
 	for i := 4; i < 513; i *= 2 {
 		for codecName, codec := range codecs {
@@ -103,7 +104,8 @@ func BenchmarkExtensionEncoding(b *testing.B) {
 	}
 }
 
-// BenchmarkExtension benchmarks extending datasquares sizes 4-128 using all supported codecs
+// BenchmarkExtension benchmarks extending datasquares sizes 4-128 using all
+// supported codecs (both encoding and root computation)
 func BenchmarkExtensionWithRoots(b *testing.B) {
 	for i := 4; i < 513; i *= 2 {
 		for codecName, codec := range codecs {


### PR DESCRIPTION
- Revamps benchmarks to include separate benchmarks for extension with encoding only, and extension with both encoding and root computation
- Standardize the benchmark names
- Increase the max ODS size to 512x512

```
goos: linux
goarch: amd64
pkg: github.com/celestiaorg/rsmt2d
cpu: 11th Gen Intel(R) Core(TM) i9-11900H @ 2.50GHz
BenchmarkEncoding/RSGF8_128_shares-16         	    8947	    132586 ns/op
BenchmarkEncoding/LeopardFF8_128_shares-16    	   10000	    103114 ns/op
BenchmarkEncoding/LeopardFF16_128_shares-16   	   12720	     92157 ns/op
BenchmarkDecoding/RSGF8_128_shares-16         	   80637	     14037 ns/op
BenchmarkDecoding/LeopardFF8_128_shares-16    	   10000	    126312 ns/op
BenchmarkDecoding/LeopardFF16_128_shares-16   	   11118	    109462 ns/op
BenchmarkEDSRoots/32x32x256_ODS-16            	     126	   9711707 ns/op
BenchmarkEDSRoots/64x64x256_ODS-16            	      33	  35139466 ns/op
BenchmarkEDSRoots/128x128x256_ODS-16          	       7	 144728936 ns/op
BenchmarkEDSRoots/256x256x256_ODS-16          	       2	 582973194 ns/op
BenchmarkEDSRoots/512x512x256_ODS-16          	       1	2465700119 ns/op
BenchmarkRepair/RSGF8_4x4x256_ODS-16          	    6556	    176394 ns/op
BenchmarkRepair/LeopardFF8_4x4x256_ODS-16     	    4258	    274935 ns/op
BenchmarkRepair/LeopardFF16_4x4x256_ODS-16    	    4076	    275170 ns/op
BenchmarkRepair/RSGF8_8x8x256_ODS-16          	    1736	    680156 ns/op
BenchmarkRepair/LeopardFF8_8x8x256_ODS-16     	    1106	   1182114 ns/op
BenchmarkRepair/LeopardFF16_8x8x256_ODS-16    	    1074	   1143223 ns/op
BenchmarkRepair/RSGF8_16x16x256_ODS-16        	     367	   3246940 ns/op
BenchmarkRepair/LeopardFF8_16x16x256_ODS-16   	     223	   5092959 ns/op
BenchmarkRepair/LeopardFF16_16x16x256_ODS-16  	     231	   4949740 ns/op
BenchmarkRepair/RSGF8_32x32x256_ODS-16        	      74	  15045167 ns/op
BenchmarkRepair/LeopardFF8_32x32x256_ODS-16   	      43	  25396999 ns/op
BenchmarkRepair/LeopardFF16_32x32x256_ODS-16  	      52	  22528113 ns/op
BenchmarkRepair/RSGF8_64x64x256_ODS-16        	      18	  63405647 ns/op
BenchmarkRepair/LeopardFF8_64x64x256_ODS-16   	      16	  79474985 ns/op
BenchmarkRepair/LeopardFF16_64x64x256_ODS-16  	      16	  81732211 ns/op
BenchmarkRepair/RSGF8_128x128x256_ODS-16      	       4	 268456648 ns/op
BenchmarkRepair/LeopardFF8_128x128x256_ODS-16 	       4	 271078664 ns/op
BenchmarkRepair/LeopardFF16_128x128x256_ODS-16         	       4	 268314938 ns/op
BenchmarkRepair/LeopardFF16_256x256x256_ODS-16         	       1	3466972169 ns/op
BenchmarkRepair/LeopardFF16_512x512x256_ODS-16         	       1	12676676494 ns/op
BenchmarkExtensionEncoding/RSGF8_4x4x256_ODS-16        	  113290	      9756 ns/op
BenchmarkExtensionEncoding/LeopardFF8_4x4x256_ODS-16   	   14959	     67941 ns/op
BenchmarkExtensionEncoding/LeopardFF16_4x4x256_ODS-16  	   21992	     70991 ns/op
BenchmarkExtensionEncoding/RSGF8_8x8x256_ODS-16        	   26941	     45820 ns/op
BenchmarkExtensionEncoding/LeopardFF8_8x8x256_ODS-16   	    5822	    205148 ns/op
BenchmarkExtensionEncoding/LeopardFF16_8x8x256_ODS-16  	    5588	    190895 ns/op
BenchmarkExtensionEncoding/RSGF8_16x16x256_ODS-16      	    4500	    242753 ns/op
BenchmarkExtensionEncoding/LeopardFF8_16x16x256_ODS-16 	    1438	    746120 ns/op
BenchmarkExtensionEncoding/LeopardFF16_16x16x256_ODS-16         	    1618	    744144 ns/op
BenchmarkExtensionEncoding/RSGF8_32x32x256_ODS-16               	     758	   1521649 ns/op
BenchmarkExtensionEncoding/LeopardFF8_32x32x256_ODS-16          	     376	   3101532 ns/op
BenchmarkExtensionEncoding/LeopardFF16_32x32x256_ODS-16         	     363	   3314106 ns/op
BenchmarkExtensionEncoding/RSGF8_64x64x256_ODS-16               	     100	  10704099 ns/op
BenchmarkExtensionEncoding/LeopardFF8_64x64x256_ODS-16          	      98	  12463694 ns/op
BenchmarkExtensionEncoding/LeopardFF16_64x64x256_ODS-16         	      99	  12105027 ns/op
BenchmarkExtensionEncoding/RSGF8_128x128x256_ODS-16             	      15	  72717822 ns/op
BenchmarkExtensionEncoding/LeopardFF8_128x128x256_ODS-16        	      25	  46558963 ns/op
BenchmarkExtensionEncoding/LeopardFF16_128x128x256_ODS-16       	      26	  46780218 ns/op
BenchmarkExtensionEncoding/LeopardFF16_256x256x256_ODS-16       	       3	 377206163 ns/op
BenchmarkExtensionEncoding/LeopardFF16_512x512x256_ODS-16       	       1	1321187103 ns/op
BenchmarkExtensionWithRoots/RSGF8_4x4x256_ODS-16                	    6928	    164996 ns/op
BenchmarkExtensionWithRoots/LeopardFF8_4x4x256_ODS-16           	    5810	    222551 ns/op
BenchmarkExtensionWithRoots/LeopardFF16_4x4x256_ODS-16          	    6199	    203213 ns/op
BenchmarkExtensionWithRoots/RSGF8_8x8x256_ODS-16                	    1435	    719689 ns/op
BenchmarkExtensionWithRoots/LeopardFF8_8x8x256_ODS-16           	    1534	    907504 ns/op
BenchmarkExtensionWithRoots/LeopardFF16_8x8x256_ODS-16          	    1539	    907725 ns/op
BenchmarkExtensionWithRoots/LeopardFF8_16x16x256_ODS-16         	     344	   3486967 ns/op
BenchmarkExtensionWithRoots/LeopardFF16_16x16x256_ODS-16        	     327	   3090775 ns/op
BenchmarkExtensionWithRoots/RSGF8_16x16x256_ODS-16              	     475	   2720996 ns/op
BenchmarkExtensionWithRoots/LeopardFF16_32x32x256_ODS-16        	      85	  13668114 ns/op
BenchmarkExtensionWithRoots/RSGF8_32x32x256_ODS-16              	     100	  12069552 ns/op
BenchmarkExtensionWithRoots/LeopardFF8_32x32x256_ODS-16         	      90	  13171137 ns/op
BenchmarkExtensionWithRoots/RSGF8_64x64x256_ODS-16              	      24	  51309966 ns/op
BenchmarkExtensionWithRoots/LeopardFF8_64x64x256_ODS-16         	      22	  50089394 ns/op
BenchmarkExtensionWithRoots/LeopardFF16_64x64x256_ODS-16        	      20	  52109462 ns/op
BenchmarkExtensionWithRoots/RSGF8_128x128x256_ODS-16            	       5	 234330508 ns/op
BenchmarkExtensionWithRoots/LeopardFF8_128x128x256_ODS-16       	       5	 206387092 ns/op
BenchmarkExtensionWithRoots/LeopardFF16_128x128x256_ODS-16      	       5	 205415308 ns/op
BenchmarkExtensionWithRoots/LeopardFF16_256x256x256_ODS-16      	       1	1095287695 ns/op
BenchmarkExtensionWithRoots/LeopardFF16_512x512x256_ODS-16      	       1	3943786319 ns/op
PASS
ok  	github.com/celestiaorg/rsmt2d	134.281s
```