### PR TITLE
fix: check for nil before setting nil

### DIFF
--- a/datasquare.go
+++ b/datasquare.go
@@ -176,8 +176,12 @@ func (ds *dataSquare) setColSlice(x uint, y uint, newCol [][]byte) error {
 }
 
 func (ds *dataSquare) resetRoots() {
-	ds.rowRoots = nil
-	ds.colRoots = nil
+	if ds.rowRoots != nil {
+		ds.rowRoots = nil
+	}
+	if ds.colRoots != nil {
+		ds.colRoots = nil
+	}
 }
 
 func (ds *dataSquare) computeRoots() {


### PR DESCRIPTION
This change is motivated by the race conditions I observed. The roots are reset every time we do `SetCell` by setting nil. However, it causes race conditions between multiple `SetCell` calls. This change fixes this and is tested against celestia-node