### PR TITLE
Fix/parallel repair

### DIFF
--- a/extendeddatacrossword.go
+++ b/extendeddatacrossword.go
@@ -84,7 +84,7 @@ func (eds *ExtendedDataSquare) solveCrossword(
 		// Track if a single iteration of this loop made progress
 		progressMade := false
 
-		var foo sync.Mutex
+		var mut sync.Mutex
 		var wg sync.WaitGroup
 		wg.Add(int(eds.width))
 
@@ -99,8 +99,8 @@ func (eds *ExtendedDataSquare) solveCrossword(
 					return err
 				}
 
-				foo.Lock()
-				defer foo.Unlock()
+				mut.Lock()
+				defer mut.Unlock()
 				solved = solved && solvedRow
 				progressMade = progressMade || progressMadeRow
 				return nil
@@ -113,8 +113,8 @@ func (eds *ExtendedDataSquare) solveCrossword(
 					return err
 				}
 
-				foo.Lock()
-				defer foo.Unlock()
+				mut.Lock()
+				defer mut.Unlock()
 				solved = solved && solvedCol
 				progressMade = progressMade || progressMadeCol
 				return nil

--- a/extendeddatacrossword.go
+++ b/extendeddatacrossword.go
@@ -85,12 +85,15 @@ func (eds *ExtendedDataSquare) solveCrossword(
 		progressMade := false
 
 		var foo sync.Mutex
+		var wg sync.WaitGroup
+		wg.Add(int(eds.width))
 
 		// Loop through every row and column, attempt to rebuild each row or column if incomplete
 		for i := 0; i < int(eds.width); i++ {
 			i := i
 
 			errs.Go(func() error {
+				defer wg.Done()
 				solvedRow, progressMadeRow, err := eds.solveCrosswordRow(i, rowRoots, colRoots)
 				if err != nil {
 					return err
@@ -104,6 +107,7 @@ func (eds *ExtendedDataSquare) solveCrossword(
 			})
 
 			errs.Go(func() error {
+				wg.Wait()
 				solvedCol, progressMadeCol, err := eds.solveCrosswordCol(i, rowRoots, colRoots)
 				if err != nil {
 					return err

--- a/extendeddatacrossword.go
+++ b/extendeddatacrossword.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
 
 	"golang.org/x/sync/errgroup"
 )
@@ -83,6 +84,8 @@ func (eds *ExtendedDataSquare) solveCrossword(
 		// Track if a single iteration of this loop made progress
 		progressMade := false
 
+		var foo sync.Mutex
+
 		// Loop through every row and column, attempt to rebuild each row or column if incomplete
 		for i := 0; i < int(eds.width); i++ {
 			i := i
@@ -93,6 +96,8 @@ func (eds *ExtendedDataSquare) solveCrossword(
 					return err
 				}
 
+				foo.Lock()
+				defer foo.Unlock()
 				solved = solved && solvedRow
 				progressMade = progressMade || progressMadeRow
 				return nil
@@ -104,6 +109,8 @@ func (eds *ExtendedDataSquare) solveCrossword(
 					return err
 				}
 
+				foo.Lock()
+				defer foo.Unlock()
 				solved = solved && solvedCol
 				progressMade = progressMade || progressMadeCol
 				return nil


### PR DESCRIPTION
`solveCrosswordRow` sets cells for the crossword which are accessed in `solveCrosswordColumn`, which means that both being run in parallel has a race condition.

This PR resolves this by running all `solveCrosswordRow` in parallel and waiting for all these calls to finish before executing all `solveCrosswordColumn` calls in parallel

- [x] Fixes #123