### PR TITLE
fix: parallel repair

### DIFF
--- a/datasquare.go
+++ b/datasquare.go
@@ -255,9 +255,6 @@ func (ds *dataSquare) getColRoot(y uint) []byte {
 
 // GetCell returns a copy of a specific cell.
 func (ds *dataSquare) GetCell(x uint, y uint) []byte {
-	ds.dataMutex.Lock()
-	defer ds.dataMutex.Unlock()
-
 	if ds.squareRow[x][y] == nil {
 		return nil
 	}
@@ -269,9 +266,6 @@ func (ds *dataSquare) GetCell(x uint, y uint) []byte {
 // SetCell sets a specific cell. Cell to set must be `nil`.
 // Panics if attempting to set a cell that is not `nil`.
 func (ds *dataSquare) SetCell(x uint, y uint, newChunk []byte) {
-	ds.dataMutex.Lock()
-	defer ds.dataMutex.Unlock()
-
 	if ds.squareRow[x][y] != nil {
 		panic(fmt.Sprintf("cannot set cell (%d, %d) as it already has a value %x", x, y, ds.squareRow[x][y]))
 	}
@@ -282,9 +276,6 @@ func (ds *dataSquare) SetCell(x uint, y uint, newChunk []byte) {
 
 // setCell sets a specific cell.
 func (ds *dataSquare) setCell(x uint, y uint, newChunk []byte) {
-	ds.dataMutex.Lock()
-	defer ds.dataMutex.Unlock()
-
 	ds.squareRow[x][y] = newChunk
 	ds.squareCol[y][x] = newChunk
 	ds.resetRoots()
@@ -292,9 +283,6 @@ func (ds *dataSquare) setCell(x uint, y uint, newChunk []byte) {
 
 // Flattened returns the concatenated rows of the data square.
 func (ds *dataSquare) Flattened() [][]byte {
-	ds.dataMutex.Lock()
-	defer ds.dataMutex.Unlock()
-
 	flattened := [][]byte(nil)
 	for _, data := range ds.squareRow {
 		flattened = append(flattened, data...)

--- a/datasquare.go
+++ b/datasquare.go
@@ -255,6 +255,9 @@ func (ds *dataSquare) getColRoot(y uint) []byte {
 
 // GetCell returns a copy of a specific cell.
 func (ds *dataSquare) GetCell(x uint, y uint) []byte {
+	ds.dataMutex.Lock()
+	defer ds.dataMutex.Unlock()
+
 	if ds.squareRow[x][y] == nil {
 		return nil
 	}
@@ -266,6 +269,9 @@ func (ds *dataSquare) GetCell(x uint, y uint) []byte {
 // SetCell sets a specific cell. Cell to set must be `nil`.
 // Panics if attempting to set a cell that is not `nil`.
 func (ds *dataSquare) SetCell(x uint, y uint, newChunk []byte) {
+	ds.dataMutex.Lock()
+	defer ds.dataMutex.Unlock()
+
 	if ds.squareRow[x][y] != nil {
 		panic(fmt.Sprintf("cannot set cell (%d, %d) as it already has a value %x", x, y, ds.squareRow[x][y]))
 	}
@@ -276,6 +282,9 @@ func (ds *dataSquare) SetCell(x uint, y uint, newChunk []byte) {
 
 // setCell sets a specific cell.
 func (ds *dataSquare) setCell(x uint, y uint, newChunk []byte) {
+	ds.dataMutex.Lock()
+	defer ds.dataMutex.Unlock()
+
 	ds.squareRow[x][y] = newChunk
 	ds.squareCol[y][x] = newChunk
 	ds.resetRoots()
@@ -283,6 +292,9 @@ func (ds *dataSquare) setCell(x uint, y uint, newChunk []byte) {
 
 // Flattened returns the concatenated rows of the data square.
 func (ds *dataSquare) Flattened() [][]byte {
+	ds.dataMutex.Lock()
+	defer ds.dataMutex.Unlock()
+
 	flattened := [][]byte(nil)
 	for _, data := range ds.squareRow {
 		flattened = append(flattened, data...)

--- a/extendeddatacrossword.go
+++ b/extendeddatacrossword.go
@@ -84,7 +84,7 @@ func (eds *ExtendedDataSquare) solveCrossword(
 		// Track if a single iteration of this loop made progress
 		progressMade := false
 
-		var trackerMutex sync.Mutex
+		var statusMutex sync.Mutex
 		// Loop through every row and column, attempt to rebuild each row or column if incomplete
 		for i := 0; i < int(eds.width); i++ {
 			i := i
@@ -95,8 +95,8 @@ func (eds *ExtendedDataSquare) solveCrossword(
 					return err
 				}
 
-				trackerMutex.Lock()
-				defer trackerMutex.Unlock()
+				statusMutex.Lock()
+				defer statusMutex.Unlock()
 				solved = solved && solvedRow
 				progressMade = progressMade || progressMadeRow
 				return nil
@@ -116,8 +116,8 @@ func (eds *ExtendedDataSquare) solveCrossword(
 					return err
 				}
 
-				trackerMutex.Lock()
-				defer trackerMutex.Unlock()
+				statusMutex.Lock()
+				defer statusMutex.Unlock()
 				solved = solved && solvedCol
 				progressMade = progressMade || progressMadeCol
 				return nil

--- a/extendeddatacrossword.go
+++ b/extendeddatacrossword.go
@@ -84,7 +84,7 @@ func (eds *ExtendedDataSquare) solveCrossword(
 		// Track if a single iteration of this loop made progress
 		progressMade := false
 
-		var mut sync.Mutex
+		var trackerMutex sync.Mutex
 		// Loop through every row and column, attempt to rebuild each row or column if incomplete
 		for i := 0; i < int(eds.width); i++ {
 			i := i
@@ -95,8 +95,8 @@ func (eds *ExtendedDataSquare) solveCrossword(
 					return err
 				}
 
-				mut.Lock()
-				defer mut.Unlock()
+				trackerMutex.Lock()
+				defer trackerMutex.Unlock()
 				solved = solved && solvedRow
 				progressMade = progressMade || progressMadeRow
 				return nil
@@ -116,8 +116,8 @@ func (eds *ExtendedDataSquare) solveCrossword(
 					return err
 				}
 
-				mut.Lock()
-				defer mut.Unlock()
+				trackerMutex.Lock()
+				defer trackerMutex.Unlock()
 				solved = solved && solvedCol
 				progressMade = progressMade || progressMadeCol
 				return nil

--- a/extendeddatacrossword.go
+++ b/extendeddatacrossword.go
@@ -85,15 +85,11 @@ func (eds *ExtendedDataSquare) solveCrossword(
 		progressMade := false
 
 		var mut sync.Mutex
-		var wg sync.WaitGroup
-		wg.Add(int(eds.width))
-
 		// Loop through every row and column, attempt to rebuild each row or column if incomplete
 		for i := 0; i < int(eds.width); i++ {
 			i := i
 
 			errs.Go(func() error {
-				defer wg.Done()
 				solvedRow, progressMadeRow, err := eds.solveCrosswordRow(i, rowRoots, colRoots)
 				if err != nil {
 					return err
@@ -106,8 +102,15 @@ func (eds *ExtendedDataSquare) solveCrossword(
 				return nil
 			})
 
+		}
+		if err := errs.Wait(); err != nil {
+			return err
+		}
+
+		for i := 0; i < int(eds.width); i++ {
+			i := i
+
 			errs.Go(func() error {
-				wg.Wait()
 				solvedCol, progressMadeCol, err := eds.solveCrosswordCol(i, rowRoots, colRoots)
 				if err != nil {
 					return err
@@ -120,7 +123,6 @@ func (eds *ExtendedDataSquare) solveCrossword(
 				return nil
 			})
 		}
-
 		if err := errs.Wait(); err != nil {
 			return err
 		}

--- a/extendeddatacrossword.go
+++ b/extendeddatacrossword.go
@@ -186,6 +186,8 @@ func (eds *ExtendedDataSquare) solveCrosswordRow(
 		if col[r] != nil {
 			continue // not newly completed
 		}
+
+		eds.rowColMutex[c].Lock()
 		col[r] = rebuiltShares[c]
 		if noMissingData(col) { // not completed
 			err := eds.verifyAgainstColRoots(colRoots, uint(c), col)
@@ -193,11 +195,14 @@ func (eds *ExtendedDataSquare) solveCrosswordRow(
 				return false, false, err
 			}
 		}
+		eds.rowColMutex[c].Unlock()
 	}
 
 	// Insert rebuilt shares into square.
 	for c, s := range rebuiltShares {
+		eds.rowColMutex[c].Lock()
 		eds.setCell(uint(r), uint(c), s)
+		eds.rowColMutex[c].Unlock()
 	}
 
 	return true, true, nil
@@ -248,6 +253,8 @@ func (eds *ExtendedDataSquare) solveCrosswordCol(
 		if row[c] != nil {
 			continue // not newly completed
 		}
+
+		eds.rowColMutex[r].Lock()
 		row[c] = rebuiltShares[r]
 		if noMissingData(row) { // not completed
 			err := eds.verifyAgainstRowRoots(rowRoots, uint(r), row)
@@ -255,11 +262,14 @@ func (eds *ExtendedDataSquare) solveCrosswordCol(
 				return false, false, err
 			}
 		}
+		eds.rowColMutex[r].Unlock()
 	}
 
 	// Insert rebuilt shares into square.
 	for r, s := range rebuiltShares {
+		eds.rowColMutex[r].Lock()
 		eds.setCell(uint(r), uint(c), s)
+		eds.rowColMutex[r].Unlock()
 	}
 
 	return true, true, nil

--- a/extendeddatacrossword.go
+++ b/extendeddatacrossword.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
 
 	"golang.org/x/sync/errgroup"
 )
@@ -83,6 +84,8 @@ func (eds *ExtendedDataSquare) solveCrossword(
 		// Track if a single iteration of this loop made progress
 		progressMade := false
 
+		var mut sync.Mutex
+
 		// Loop through every row and column, attempt to rebuild each row or column if incomplete
 		for i := 0; i < int(eds.width); i++ {
 			i := i
@@ -93,6 +96,8 @@ func (eds *ExtendedDataSquare) solveCrossword(
 					return err
 				}
 
+				mut.Lock()
+				defer mut.Unlock()
 				solved = solved && solvedRow
 				progressMade = progressMade || progressMadeRow
 				return nil
@@ -104,6 +109,8 @@ func (eds *ExtendedDataSquare) solveCrossword(
 					return err
 				}
 
+				mut.Lock()
+				defer mut.Unlock()
 				solved = solved && solvedCol
 				progressMade = progressMade || progressMadeCol
 				return nil

--- a/extendeddatacrossword.go
+++ b/extendeddatacrossword.go
@@ -85,12 +85,15 @@ func (eds *ExtendedDataSquare) solveCrossword(
 		progressMade := false
 
 		var mut sync.Mutex
+		var wg sync.WaitGroup
+		wg.Add(int(eds.width))
 
 		// Loop through every row and column, attempt to rebuild each row or column if incomplete
 		for i := 0; i < int(eds.width); i++ {
 			i := i
 
 			errs.Go(func() error {
+				defer wg.Done()
 				solvedRow, progressMadeRow, err := eds.solveCrosswordRow(i, rowRoots, colRoots)
 				if err != nil {
 					return err
@@ -104,6 +107,7 @@ func (eds *ExtendedDataSquare) solveCrossword(
 			})
 
 			errs.Go(func() error {
+				wg.Wait()
 				solvedCol, progressMadeCol, err := eds.solveCrosswordCol(i, rowRoots, colRoots)
 				if err != nil {
 					return err

--- a/extendeddatasquare.go
+++ b/extendeddatasquare.go
@@ -5,8 +5,6 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"sync"
-
 	"golang.org/x/sync/errgroup"
 )
 
@@ -15,7 +13,6 @@ type ExtendedDataSquare struct {
 	*dataSquare
 	codec             Codec
 	originalDataWidth uint
-	rowColMutex       []sync.Mutex
 }
 
 // ComputeExtendedDataSquare computes the extended data square for some chunks of data.
@@ -33,7 +30,7 @@ func ComputeExtendedDataSquare(
 		return nil, err
 	}
 
-	eds := ExtendedDataSquare{dataSquare: ds, codec: codec, rowColMutex: make([]sync.Mutex, ds.width)}
+	eds := ExtendedDataSquare{dataSquare: ds, codec: codec}
 	err = eds.erasureExtendSquare(codec)
 	if err != nil {
 		return nil, err
@@ -57,7 +54,7 @@ func ImportExtendedDataSquare(
 		return nil, err
 	}
 
-	eds := ExtendedDataSquare{dataSquare: ds, codec: codec, rowColMutex: make([]sync.Mutex, ds.width)}
+	eds := ExtendedDataSquare{dataSquare: ds, codec: codec}
 	if eds.width%2 != 0 {
 		return nil, errors.New("square width must be even")
 	}

--- a/extendeddatasquare.go
+++ b/extendeddatasquare.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"sync"
 
 	"golang.org/x/sync/errgroup"
 )
@@ -14,6 +15,7 @@ type ExtendedDataSquare struct {
 	*dataSquare
 	codec             Codec
 	originalDataWidth uint
+	rowColMutex       []sync.Mutex
 }
 
 // ComputeExtendedDataSquare computes the extended data square for some chunks of data.
@@ -31,7 +33,7 @@ func ComputeExtendedDataSquare(
 		return nil, err
 	}
 
-	eds := ExtendedDataSquare{dataSquare: ds, codec: codec}
+	eds := ExtendedDataSquare{dataSquare: ds, codec: codec, rowColMutex: make([]sync.Mutex, ds.width)}
 	err = eds.erasureExtendSquare(codec)
 	if err != nil {
 		return nil, err
@@ -55,7 +57,7 @@ func ImportExtendedDataSquare(
 		return nil, err
 	}
 
-	eds := ExtendedDataSquare{dataSquare: ds, codec: codec}
+	eds := ExtendedDataSquare{dataSquare: ds, codec: codec, rowColMutex: make([]sync.Mutex, ds.width)}
 	if eds.width%2 != 0 {
 		return nil, errors.New("square width must be even")
 	}


### PR DESCRIPTION
`solveCrosswordRow` sets cells for the crossword which are accessed in `solveCrosswordColumn`, which means that both being run in parallel has a race condition.

This PR resolves this by running all `solveCrosswordRow` in parallel and waiting for all these calls to finish before executing all `solveCrosswordColumn` calls in parallel

- [x] Fixes #123