### PR TITLE
fix: eds mutation

### DIFF
--- a/extendeddatacrossword.go
+++ b/extendeddatacrossword.go
@@ -293,7 +293,6 @@ func (eds *ExtendedDataSquare) verifyAgainstRowRoots(
 	root := eds.computeSharesRoot(shares, Row, r)
 
 	if !bytes.Equal(root, rowRoots[r]) {
-		panic("failed at verification")
 		return &ErrByzantineData{Row, r, nil}
 	}
 

--- a/extendeddatacrossword.go
+++ b/extendeddatacrossword.go
@@ -163,7 +163,7 @@ func (eds *ExtendedDataSquare) solveCrosswordRow(
 		}
 		newCol := splitSlice{
 			head:        col[:r],
-			dataAtIndex: rebuiltShares[r],
+			dataAtIndex: rebuiltShares[c],
 			tail:        col[r+1:],
 		}
 		if noMissingDataSplitSlice(newCol) { // not completed
@@ -233,7 +233,7 @@ func (eds *ExtendedDataSquare) solveCrosswordCol(
 		}
 		newRow := splitSlice{
 			head:        row[:c],
-			dataAtIndex: rebuiltShares[c],
+			dataAtIndex: rebuiltShares[r],
 			tail:        row[c+1:],
 		}
 		if noMissingDataSplitSlice(newRow) { // not completed


### PR DESCRIPTION
Call to `eds.row` returns a slice to the underlying row/col data. Hence, when rebuilt shares are added to this slice, the underlying data is being mutated before correct validation is done. On the other hand, using `eds.Row` is too expensive, since it makes a copy of the underlying data. This PR introduces a new type `splitSlice`, which contains the slice(s) to the data before and after the index where the rebuilt share is to be inserted, but keeps a reference to proposed share rather than inserting it.

- [x] Fixes #132 