### PR TITLE
docs: remove leopard build tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,5 +76,5 @@ func main() {
 Run benchmarks
 
 ```sh
-go test -tags leopard -benchmem -bench=.
+go test -benchmem -bench=.
 ```


### PR DESCRIPTION
The build tag is not necessary after https://github.com/celestiaorg/rsmt2d/pull/136
