### PR TITLE
chore!: check newChunk size

### DIFF
--- a/datasquare.go
+++ b/datasquare.go
@@ -284,22 +284,31 @@ func (ds *dataSquare) GetCell(x uint, y uint) []byte {
 	return cell
 }
 
-// SetCell sets a specific cell. Cell to set must be `nil`.
-// Panics if attempting to set a cell that is not `nil`.
-func (ds *dataSquare) SetCell(x uint, y uint, newChunk []byte) {
+// SetCell sets a specific cell. The cell to set must be `nil`. Returns an error
+// if the cell to set is not `nil` or newChunk is not the correct size.
+func (ds *dataSquare) SetCell(x uint, y uint, newChunk []byte) error {
 	if ds.squareRow[x][y] != nil {
-		panic(fmt.Sprintf("cannot set cell (%d, %d) as it already has a value %x", x, y, ds.squareRow[x][y]))
+		return fmt.Errorf("cannot set cell (%d, %d) as it already has a value %x", x, y, ds.squareRow[x][y])
+	}
+	if len(newChunk) != int(ds.chunkSize) {
+		return fmt.Errorf("cannot set cell with chunk size %d because dataSquare chunk size is %d", len(newChunk), ds.chunkSize)
 	}
 	ds.squareRow[x][y] = newChunk
 	ds.squareCol[y][x] = newChunk
 	ds.resetRoots()
+	return nil
 }
 
-// setCell sets a specific cell.
-func (ds *dataSquare) setCell(x uint, y uint, newChunk []byte) {
+// setCell sets a specific cell. setCell will overwrite any existing value.
+// Returns an error if the newChunk is not the correct size.
+func (ds *dataSquare) setCell(x uint, y uint, newChunk []byte) error {
+	if len(newChunk) != int(ds.chunkSize) {
+		return fmt.Errorf("cannot set cell with chunk size %d because dataSquare chunk size is %d", len(newChunk), ds.chunkSize)
+	}
 	ds.squareRow[x][y] = newChunk
 	ds.squareCol[y][x] = newChunk
 	ds.resetRoots()
+	return nil
 }
 
 // Flattened returns the concatenated rows of the data square.

--- a/datasquare_test.go
+++ b/datasquare_test.go
@@ -69,6 +69,17 @@ func TestSetCell(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func Test_setCell(t *testing.T) {
+	ds, err := newDataSquare([][]byte{{1}, {2}, {3}, {4}}, NewDefaultTree)
+	assert.NoError(t, err)
+
+	err = ds.setCell(0, 0, []byte{42})
+	assert.NoError(t, err)
+
+	err = ds.setCell(0, 0, []byte{0, 1}) // incorrect chunk size
+	assert.Error(t, err)
+}
+
 func TestGetCell(t *testing.T) {
 	ds, err := newDataSquare([][]byte{{1}, {2}, {3}, {4}}, NewDefaultTree)
 	if err != nil {

--- a/datasquare_test.go
+++ b/datasquare_test.go
@@ -53,18 +53,20 @@ func TestInvalidDataSquareCreation(t *testing.T) {
 
 func TestSetCell(t *testing.T) {
 	ds, err := newDataSquare([][]byte{{1}, {2}, {3}, {4}}, NewDefaultTree)
-	if err != nil {
-		panic(err)
-	}
+	assert.NoError(t, err)
 
-	// SetCell can only write to nil cells
-	assert.Panics(t, func() { ds.SetCell(0, 0, []byte{0}) })
-
-	// Set the cell to nil to allow modification
-	ds.setCell(0, 0, nil)
-
-	ds.SetCell(0, 0, []byte{42})
+	err = ds.setCell(0, 0, []byte{42})
+	assert.NoError(t, err)
 	assert.Equal(t, []byte{42}, ds.GetCell(0, 0))
+
+	// SetCell can only write nil cells so this should return an error.
+	err = ds.SetCell(0, 0, []byte{0})
+	assert.Error(t, err)
+
+	// SetCell can only write chunks of the same size as the data square so this
+	// should return an error.
+	err = ds.SetCell(0, 0, []byte{0, 0})
+	assert.Error(t, err)
 }
 
 func TestGetCell(t *testing.T) {

--- a/datasquare_test.go
+++ b/datasquare_test.go
@@ -96,14 +96,48 @@ func TestSetCell(t *testing.T) {
 }
 
 func Test_setCell(t *testing.T) {
-	ds, err := newDataSquare([][]byte{{1}, {2}, {3}, {4}}, NewDefaultTree)
-	assert.NoError(t, err)
+	type testCase struct {
+		name         string
+		originalCell []byte
+		newCell      []byte
+		wantErr      bool
+	}
 
-	err = ds.setCell(0, 0, []byte{42})
-	assert.NoError(t, err)
+	testCases := []testCase{
+		{
+			name:         "can set cell if originally nil",
+			originalCell: nil,
+			newCell:      []byte{42},
+			wantErr:      false,
+		},
+		{
+			name:         "can set cell if originally some value",
+			originalCell: []byte{1},
+			newCell:      []byte{42},
+			wantErr:      false,
+		},
+		{
+			name:         "expect error if new cell is not the correct chunk size",
+			originalCell: nil,
+			newCell:      []byte{1, 2}, // incorrect chunk size
+			wantErr:      true,
+		},
+	}
 
-	err = ds.setCell(0, 0, []byte{0, 1}) // incorrect chunk size
-	assert.Error(t, err)
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ds, err := newDataSquare([][]byte{tc.originalCell, {2}, {3}, {4}}, NewDefaultTree)
+			assert.NoError(t, err)
+
+			err = ds.setCell(0, 0, tc.newCell)
+			if tc.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tc.newCell, ds.GetCell(0, 0))
+			}
+		})
+	}
 }
 
 func TestGetCell(t *testing.T) {


### PR DESCRIPTION
Closes https://github.com/celestiaorg/rsmt2d/issues/170
Closes https://github.com/celestiaorg/rsmt2d/issues/127

Breaking b/c modifies the function signature of a public function: `SetCell`