### PR TITLE
chore: use deepCopy

### DIFF
--- a/extendeddatasquare.go
+++ b/extendeddatasquare.go
@@ -183,13 +183,7 @@ func (eds *ExtendedDataSquare) deepCopy(codec Codec) (ExtendedDataSquare, error)
 // Col returns a column slice.
 // This slice is a copy of the internal column slice.
 func (eds *ExtendedDataSquare) Col(y uint) [][]byte {
-	col := make([][]byte, eds.width)
-	original := eds.col(y)
-	for i, cell := range original {
-		col[i] = make([]byte, eds.chunkSize)
-		copy(col[i], cell)
-	}
-	return col
+	return deepCopy(eds.col(y))
 }
 
 // ColRoots returns the Merkle roots of all the columns in the square.


### PR DESCRIPTION
Closes https://github.com/celestiaorg/rsmt2d/issues/171

https://github.com/celestiaorg/rsmt2d/blob/f166196f5d9d0c8478c423f4803f0f3b18b43405/extendeddatasquare_test.go#L122-L143 still passes