### PR TITLE
chore!: export codec methods

### DIFF
--- a/codecs.go
+++ b/codecs.go
@@ -18,10 +18,10 @@ type Codec interface {
 	// Decode decodes sparse original + parity data, automatically extracting share size.
 	// Missing shares must be nil. Returns original + parity data.
 	Decode(data [][]byte) ([][]byte, error)
-	// maxChunks returns the max. number of chunks each code supports in a 2D square.
-	maxChunks() int
-	// name returns the name of the codec.
-	name() string
+	// MaxChunks returns the max. number of chunks each code supports in a 2D square.
+	MaxChunks() int
+	// Name returns the name of the codec.
+	Name() string
 }
 
 // codecs is a global map used for keeping track of registered codecs for testing and JSON unmarshalling

--- a/extendeddatacrossword_test.go
+++ b/extendeddatacrossword_test.go
@@ -213,7 +213,7 @@ func BenchmarkRepair(b *testing.B) {
 	// For different ODS sizes
 	for originalDataWidth := 4; originalDataWidth <= 512; originalDataWidth *= 2 {
 		for codecName, codec := range codecs {
-			if codec.maxChunks() < originalDataWidth*originalDataWidth {
+			if codec.MaxChunks() < originalDataWidth*originalDataWidth {
 				// Only test codecs that support this many chunks
 				continue
 			}

--- a/extendeddatasquare.go
+++ b/extendeddatasquare.go
@@ -23,7 +23,7 @@ func (eds *ExtendedDataSquare) MarshalJSON() ([]byte, error) {
 		Codec      string   `json:"codec"`
 	}{
 		DataSquare: eds.dataSquare.Flattened(),
-		Codec:      eds.codec.name(),
+		Codec:      eds.codec.Name(),
 	})
 }
 
@@ -50,7 +50,7 @@ func ComputeExtendedDataSquare(
 	codec Codec,
 	treeCreatorFn TreeConstructorFn,
 ) (*ExtendedDataSquare, error) {
-	if len(data) > codec.maxChunks() {
+	if len(data) > codec.MaxChunks() {
 		return nil, errors.New("number of chunks exceeds the maximum")
 	}
 
@@ -74,7 +74,7 @@ func ImportExtendedDataSquare(
 	codec Codec,
 	treeCreatorFn TreeConstructorFn,
 ) (*ExtendedDataSquare, error) {
-	if len(data) > 4*codec.maxChunks() {
+	if len(data) > 4*codec.MaxChunks() {
 		return nil, errors.New("number of chunks exceeds the maximum")
 	}
 

--- a/extendeddatasquare_test.go
+++ b/extendeddatasquare_test.go
@@ -151,7 +151,7 @@ var dump *ExtendedDataSquare
 func BenchmarkExtensionEncoding(b *testing.B) {
 	for i := 4; i < 513; i *= 2 {
 		for codecName, codec := range codecs {
-			if codec.maxChunks() < i*i {
+			if codec.MaxChunks() < i*i {
 				// Only test codecs that support this many chunks
 				continue
 			}
@@ -179,7 +179,7 @@ func BenchmarkExtensionEncoding(b *testing.B) {
 func BenchmarkExtensionWithRoots(b *testing.B) {
 	for i := 4; i < 513; i *= 2 {
 		for codecName, codec := range codecs {
-			if codec.maxChunks() < i*i {
+			if codec.MaxChunks() < i*i {
 				// Only test codecs that support this many chunks
 				continue
 			}

--- a/leopard.go
+++ b/leopard.go
@@ -67,11 +67,11 @@ func (l *leoRSCodec) loadOrInitEncoder(dataLen int) (reedsolomon.Encoder, error)
 
 }
 
-func (l *leoRSCodec) maxChunks() int {
+func (l *leoRSCodec) MaxChunks() int {
 	return 32768 * 32768
 }
 
-func (l *leoRSCodec) name() string {
+func (l *leoRSCodec) Name() string {
 	return Leopard
 }
 


### PR DESCRIPTION
## Overview

If the methods for the `Codec` interface are exported, then users can define their own interfaces outside of this package. I'm not sure if leaving the methods unexported was done on purpose, so if it was this PR can be closed.

edit: for posterity this [PR](https://github.com/celestiaorg/rsmt2d/pull/46/files) exported only a few methods, so it looks like it wasn't done on purpose, but I'm still unsure if there are any other specific reasons not to 

## Checklist

- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [x] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords
