### PR TITLE
refactor: simplify `rebuildShares`

### DIFF
--- a/extendeddatacrossword.go
+++ b/extendeddatacrossword.go
@@ -259,25 +259,6 @@ func (eds *ExtendedDataSquare) rebuildShares(
 		return nil, false, nil
 	}
 
-	if isExtendedPartIncomplete {
-		// If needed, rebuild the parity shares too.
-		rebuiltExtendedShares, err := eds.codec.Encode(rebuiltShares[0:eds.originalDataWidth])
-		if err != nil {
-			return nil, true, err
-		}
-		rebuiltShares = append(
-			rebuiltShares[0:eds.originalDataWidth],
-			rebuiltExtendedShares...,
-		)
-	} else {
-		// Otherwise copy them from the EDS.
-		startIndex := len(shares) - int(eds.originalDataWidth)
-		rebuiltShares = append(
-			rebuiltShares[0:eds.originalDataWidth],
-			shares[startIndex:]...,
-		)
-	}
-
 	return rebuiltShares, true, nil
 }
 

--- a/extendeddatacrossword.go
+++ b/extendeddatacrossword.go
@@ -136,9 +136,8 @@ func (eds *ExtendedDataSquare) solveCrosswordRow(
 		shares[c] = vectorData[c]
 	}
 
-	isExtendedPartIncomplete := !eds.rowRangeNoMissingData(uint(r), eds.originalDataWidth, eds.width)
 	// Attempt rebuild
-	rebuiltShares, isDecoded, err := eds.rebuildShares(isExtendedPartIncomplete, shares)
+	rebuiltShares, isDecoded, err := eds.rebuildShares(shares)
 	if err != nil {
 		return false, false, err
 	}
@@ -201,9 +200,8 @@ func (eds *ExtendedDataSquare) solveCrosswordCol(
 
 	}
 
-	isExtendedPartIncomplete := !eds.colRangeNoMissingData(uint(c), eds.originalDataWidth, eds.width)
 	// Attempt rebuild
-	rebuiltShares, isDecoded, err := eds.rebuildShares(isExtendedPartIncomplete, shares)
+	rebuiltShares, isDecoded, err := eds.rebuildShares(shares)
 	if err != nil {
 		return false, false, err
 	}
@@ -249,7 +247,6 @@ func (eds *ExtendedDataSquare) solveCrosswordCol(
 // 2. Whether the original shares could be decoded from the shares parameter.
 // 3. [Optional] an error.
 func (eds *ExtendedDataSquare) rebuildShares(
-	isExtendedPartIncomplete bool,
 	shares [][]byte,
 ) ([][]byte, bool, error) {
 	rebuiltShares, err := eds.codec.Decode(shares)
@@ -407,22 +404,4 @@ func (eds *ExtendedDataSquare) computeSharesRootWithRebuiltShare(shares [][]byte
 		tree.Push(d)
 	}
 	return tree.Root()
-}
-
-func (eds *ExtendedDataSquare) rowRangeNoMissingData(r, start, end uint) bool {
-	for c := start; c <= end && c < eds.width; c++ {
-		if eds.squareRow[r][c] == nil {
-			return false
-		}
-	}
-	return true
-}
-
-func (eds *ExtendedDataSquare) colRangeNoMissingData(c, start, end uint) bool {
-	for r := start; r <= end && r < eds.width; r++ {
-		if eds.squareRow[r][c] == nil {
-			return false
-		}
-	}
-	return true
 }


### PR DESCRIPTION
Closes https://github.com/celestiaorg/rsmt2d/issues/196

Since [`Decode`](https://github.com/rootulp/rsmt2d/blob/1f1904acc114b41dff838ad1d530feacc1d9f199/leopard.go#L46-L54) returns original + parity shares, there is no need to separately rebuild the parity shares. This PR removes an unnecessary conditional inside `rebuildShares` which let us also remove a param to that function. After the refactor, a few helper methods were no longer used so they were also removed.