### PR TITLE
chore: bump to Go 1.20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ on:
       - master
       - release/**
 
+env:
+  GO_VERSION: '1.20'
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -18,7 +21,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: "1.18"
+          go-version: ${{ env.GO_VERSION }}
       - uses: actions/checkout@v2
       - uses: technote-space/get-diff-action@v4
         with:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/celestiaorg/rsmt2d
 
-go 1.19
+go 1.20
 
 require (
 	github.com/celestiaorg/merkletree v0.0.0-20210714075610-a84dc3ddbbe4


### PR DESCRIPTION
Closes https://github.com/celestiaorg/rsmt2d/issues/210

I couldn't find any other occurrences of 1.18 or 1.19 in the repo.