### PR TITLE
feat: `NewExtendedDataSquare` with chunkSize param

### DIFF
--- a/datasquare.go
+++ b/datasquare.go
@@ -26,20 +26,15 @@ type dataSquare struct {
 	createTreeFn TreeConstructorFn
 }
 
-func newDataSquare(data [][]byte, treeCreator TreeConstructorFn) (*dataSquare, error) {
+func newDataSquare(data [][]byte, treeCreator TreeConstructorFn, chunkSize uint) (*dataSquare, error) {
 	width := int(math.Ceil(math.Sqrt(float64(len(data)))))
 	if width*width != len(data) {
 		return nil, errors.New("number of chunks must be a square number")
 	}
 
-	var chunkSize int
 	for _, d := range data {
-		if d != nil {
-			if chunkSize == 0 {
-				chunkSize = len(d)
-			} else if chunkSize != len(d) {
-				return nil, ErrUnevenChunks
-			}
+		if d != nil && len(d) != int(chunkSize) {
+			return nil, ErrUnevenChunks
 		}
 	}
 
@@ -48,7 +43,7 @@ func newDataSquare(data [][]byte, treeCreator TreeConstructorFn) (*dataSquare, e
 		squareRow[i] = data[i*width : i*width+width]
 
 		for j := 0; j < width; j++ {
-			if squareRow[i][j] != nil && len(squareRow[i][j]) != chunkSize {
+			if squareRow[i][j] != nil && len(squareRow[i][j]) != int(chunkSize) {
 				return nil, ErrUnevenChunks
 			}
 		}

--- a/extendeddatacrossword_test.go
+++ b/extendeddatacrossword_test.go
@@ -261,6 +261,7 @@ func TestCorruptedEdsReturnsErrByzantineData(t *testing.T) {
 }
 
 func BenchmarkRepair(b *testing.B) {
+	chunkSize := uint(256)
 	// For different ODS sizes
 	for originalDataWidth := 4; originalDataWidth <= 512; originalDataWidth *= 2 {
 		for codecName, codec := range codecs {
@@ -270,7 +271,7 @@ func BenchmarkRepair(b *testing.B) {
 			}
 
 			// Generate a new range original data square then extend it
-			square := genRandDS(originalDataWidth)
+			square := genRandDS(originalDataWidth, int(chunkSize))
 			eds, err := ComputeExtendedDataSquare(square, codec, NewDefaultTree)
 			if err != nil {
 				b.Error(err)

--- a/extendeddatasquare_test.go
+++ b/extendeddatasquare_test.go
@@ -96,6 +96,49 @@ func TestMarshalJSON(t *testing.T) {
 	}
 }
 
+func TestNewExtendedDataSquare(t *testing.T) {
+	t.Run("returns an error if edsWidth is not even", func(t *testing.T) {
+		edsWidth := uint(1)
+		chunkSize := uint(512)
+
+		_, err := NewExtendedDataSquare(NewLeoRSCodec(), NewDefaultTree, edsWidth, chunkSize)
+		assert.Error(t, err)
+	})
+	t.Run("returns a 4x4 EDS", func(t *testing.T) {
+		edsWidth := uint(4)
+		chunkSize := uint(512)
+
+		got, err := NewExtendedDataSquare(NewLeoRSCodec(), NewDefaultTree, edsWidth, chunkSize)
+		assert.NoError(t, err)
+		assert.Equal(t, edsWidth, got.width)
+		assert.Equal(t, chunkSize, got.chunkSize)
+	})
+	t.Run("returns a 4x4 EDS that can be populated via SetCell", func(t *testing.T) {
+		edsWidth := uint(4)
+		chunkSize := uint(512)
+
+		got, err := NewExtendedDataSquare(NewLeoRSCodec(), NewDefaultTree, edsWidth, chunkSize)
+		assert.NoError(t, err)
+
+		chunk := bytes.Repeat([]byte{1}, int(chunkSize))
+		err = got.SetCell(0, 0, chunk)
+		assert.NoError(t, err)
+		assert.Equal(t, chunk, got.squareRow[0][0])
+	})
+	t.Run("returns an error when SetCell is invoked on an EDS with a chunk that is not the correct size", func(t *testing.T) {
+		edsWidth := uint(4)
+		chunkSize := uint(512)
+		incorrectChunkSize := uint(513)
+
+		got, err := NewExtendedDataSquare(NewLeoRSCodec(), NewDefaultTree, edsWidth, chunkSize)
+		assert.NoError(t, err)
+
+		chunk := bytes.Repeat([]byte{1}, int(incorrectChunkSize))
+		err = got.SetCell(0, 0, chunk)
+		assert.Error(t, err)
+	})
+}
+
 func TestImmutableRoots(t *testing.T) {
 	codec := NewLeoRSCodec()
 	result, err := ComputeExtendedDataSquare([][]byte{

--- a/extendeddatasquare_test.go
+++ b/extendeddatasquare_test.go
@@ -161,6 +161,7 @@ var dump *ExtendedDataSquare
 // BenchmarkExtension benchmarks extending datasquares sizes 4-128 using all
 // supported codecs (encoding only)
 func BenchmarkExtensionEncoding(b *testing.B) {
+	chunkSize := 256
 	for i := 4; i < 513; i *= 2 {
 		for codecName, codec := range codecs {
 			if codec.MaxChunks() < i*i {
@@ -168,7 +169,7 @@ func BenchmarkExtensionEncoding(b *testing.B) {
 				continue
 			}
 
-			square := genRandDS(i)
+			square := genRandDS(i, chunkSize)
 			b.Run(
 				fmt.Sprintf("%s %dx%dx%d ODS", codecName, i, i, len(square[0])),
 				func(b *testing.B) {
@@ -188,6 +189,7 @@ func BenchmarkExtensionEncoding(b *testing.B) {
 // BenchmarkExtension benchmarks extending datasquares sizes 4-128 using all
 // supported codecs (both encoding and root computation)
 func BenchmarkExtensionWithRoots(b *testing.B) {
+	chunkSize := 256
 	for i := 4; i < 513; i *= 2 {
 		for codecName, codec := range codecs {
 			if codec.MaxChunks() < i*i {
@@ -195,7 +197,7 @@ func BenchmarkExtensionWithRoots(b *testing.B) {
 				continue
 			}
 
-			square := genRandDS(i)
+			square := genRandDS(i, chunkSize)
 			b.Run(
 				fmt.Sprintf("%s %dx%dx%d ODS", codecName, i, i, len(square[0])),
 				func(b *testing.B) {
@@ -216,11 +218,11 @@ func BenchmarkExtensionWithRoots(b *testing.B) {
 
 // genRandDS make a datasquare of random data, with width describing the number
 // of shares on a single side of the ds
-func genRandDS(width int) [][]byte {
+func genRandDS(width int, chunkSize int) [][]byte {
 	var ds [][]byte
 	count := width * width
 	for i := 0; i < count; i++ {
-		share := make([]byte, 256)
+		share := make([]byte, chunkSize)
 		_, err := rand.Read(share)
 		if err != nil {
 			panic(err)


### PR DESCRIPTION
Closes https://github.com/celestiaorg/rsmt2d/issues/231

This PR adds a new constructor called `NewExtendedDataSquare` that allows @celestia-node to explicitly set the `chunkSize` on an empty EDS. I choose to not drop the existing `ImportExtendedDataSquare` as proposed in https://github.com/celestiaorg/rsmt2d/issues/85 because that would be public API breaking. 

cc: @Wondertan @walldiss 