### PR TITLE
refactor: rename share to chunk

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,17 +18,17 @@ import (
 )
 
 func main() {
-    // shareSize is the size of each share (in bytes).
-    shareSize := 512
-    // Init new codec
+    // chunkSize is the size of each chunk in bytes.
+    chunkSize := 512
+    //  new codec
     codec := rsmt2d.NewLeoRSCodec()
 
-    ones := bytes.Repeat([]byte{1}, shareSize)
-    twos := bytes.Repeat([]byte{2}, shareSize)
-    threes := bytes.Repeat([]byte{3}, shareSize)
-    fours := bytes.Repeat([]byte{4}, shareSize)
+    ones := bytes.Repeat([]byte{1}, chunkSize)
+    twos := bytes.Repeat([]byte{2}, chunkSize)
+    threes := bytes.Repeat([]byte{3}, chunkSize)
+    fours := bytes.Repeat([]byte{4}, chunkSize)
 
-    // Compute parity shares
+    // Compute parity chunks
     eds, err := rsmt2d.ComputeExtendedDataSquare(
         [][]byte{
             ones, twos,
@@ -43,7 +43,7 @@ func main() {
 
     flattened := eds.Flattened()
 
-    // Delete some shares, just enough so that repairing is possible.
+    // Delete some chunks, just enough so that repairing is possible.
     flattened[0], flattened[2], flattened[3] = nil, nil, nil
     flattened[4], flattened[5], flattened[6], flattened[7] = nil, nil, nil, nil
     flattened[8], flattened[9], flattened[10] = nil, nil, nil

--- a/codec_test.go
+++ b/codec_test.go
@@ -14,13 +14,13 @@ var (
 
 func BenchmarkEncoding(b *testing.B) {
 	// generate some fake data
-	data := generateRandData(128, shareSize)
+	data := generateRandData(128, chunkSize)
 	for codecName, codec := range codecs {
 		// For some implementations we want to ensure the encoder for this data length
 		// is already cached and initialized. For this run with same sized arbitrary data.
-		_, _ = codec.Encode(generateRandData(128, shareSize))
+		_, _ = codec.Encode(generateRandData(128, chunkSize))
 		b.Run(
-			fmt.Sprintf("%s 128 shares %d", codecName, shareSize),
+			fmt.Sprintf("%s 128 chunks %d", codecName, chunkSize),
 			func(b *testing.B) {
 				for n := 0; n < b.N; n++ {
 					encodedData, err := codec.Encode(data)
@@ -52,11 +52,11 @@ func BenchmarkDecoding(b *testing.B) {
 	for codecName, codec := range codecs {
 		// For some implementations we want to ensure the encoder for this data length
 		// is already cached and initialized. For this run with same sized arbitrary data.
-		_, _ = codec.Decode(generateMissingData(128, shareSize, codec))
+		_, _ = codec.Decode(generateMissingData(128, chunkSize, codec))
 
-		data := generateMissingData(128, shareSize, codec)
+		data := generateMissingData(128, chunkSize, codec)
 		b.Run(
-			fmt.Sprintf("%s 128 shares %d", codecName, shareSize),
+			fmt.Sprintf("%s 128 chunks %d", codecName, chunkSize),
 			func(b *testing.B) {
 				for n := 0; n < b.N; n++ {
 					decodedData, err := codec.Decode(data)
@@ -78,7 +78,7 @@ func generateMissingData(count int, chunkSize int, codec Codec) [][]byte {
 	}
 	output := append(randData, encoded...)
 
-	// remove half of the shares randomly
+	// remove half of the chunks randomly
 	for i := 0; i < (count / 2); {
 		ind := rand.Intn(count)
 		if len(output[ind]) == 0 {

--- a/codecs.go
+++ b/codecs.go
@@ -6,17 +6,17 @@ const (
 	// Leopard is a codec that was originally implemented in the C++ library
 	// https://github.com/catid/leopard. rsmt2d uses a Go port of the C++
 	// library in https://github.com/klauspost/reedsolomon. The Leopard codec
-	// uses 8-bit leopard for shards less than or equal to 256. The Leopard
-	// codec uses 16-bit leopard for shards greater than 256.
+	// uses 8-bit leopard for chunks less than or equal to 256. The Leopard
+	// codec uses 16-bit leopard for chunks greater than 256.
 	Leopard = "Leopard"
 )
 
 type Codec interface {
-	// Encode encodes original data, automatically extracting share size.
-	// There must be no missing shares. Only returns parity shares.
+	// Encode encodes original data, automatically extracting chunk size.
+	// There must be no missing chunks. Only returns parity chunks.
 	Encode(data [][]byte) ([][]byte, error)
-	// Decode decodes sparse original + parity data, automatically extracting share size.
-	// Missing shares must be nil. Returns original + parity data.
+	// Decode decodes sparse original + parity data, automatically extracting chunk size.
+	// Missing chunks must be nil. Returns original + parity chunks.
 	Decode(data [][]byte) ([][]byte, error)
 	// MaxChunks returns the max number of chunks this codec supports in a 2D
 	// original data square.

--- a/datasquare.go
+++ b/datasquare.go
@@ -246,7 +246,7 @@ func (ds *dataSquare) getRowRoots() ([][]byte, error) {
 
 // getRowRoot calculates and returns the root of the selected row. Note: unlike
 // the getRowRoots method, getRowRoot does not write to the built-in cache.
-// Returns an error if the row is incomplete (i.e. some shares are nil).
+// Returns an error if the row is incomplete (i.e. some chunks are nil).
 func (ds *dataSquare) getRowRoot(x uint) ([]byte, error) {
 	if ds.rowRoots != nil {
 		return ds.rowRoots[x], nil
@@ -281,7 +281,7 @@ func (ds *dataSquare) getColRoots() ([][]byte, error) {
 
 // getColRoot calculates and returns the root of the selected row. Note: unlike
 // the getColRoots method, getColRoot does not write to the built-in cache.
-// Returns an error if the column is incomplete (i.e. some shares are nil).
+// Returns an error if the column is incomplete (i.e. some chunks are nil).
 func (ds *dataSquare) getColRoot(y uint) ([]byte, error) {
 	if ds.colRoots != nil {
 		return ds.colRoots[y], nil
@@ -337,10 +337,10 @@ func (ds *dataSquare) Flattened() [][]byte {
 	return flattened
 }
 
-// isComplete returns true if all the shares are non-nil.
-func isComplete(shares [][]byte) bool {
-	for _, share := range shares {
-		if share == nil {
+// isComplete returns true if all the chunks are non-nil.
+func isComplete(chunks [][]byte) bool {
+	for _, chunk := range chunks {
+		if chunk == nil {
 			return false
 		}
 	}

--- a/datasquare_test.go
+++ b/datasquare_test.go
@@ -403,7 +403,7 @@ func Test_setColSlice(t *testing.T) {
 
 func BenchmarkEDSRoots(b *testing.B) {
 	for i := 32; i < 513; i *= 2 {
-		square, err := newDataSquare(genRandDS(i*2, int(shareSize)), NewDefaultTree, shareSize)
+		square, err := newDataSquare(genRandDataSquare(i*2, int(chunkSize)), NewDefaultTree, chunkSize)
 		if err != nil {
 			b.Errorf("Failure to create square of size %d: %s", i, err)
 		}

--- a/extendeddatacrossword.go
+++ b/extendeddatacrossword.go
@@ -18,8 +18,8 @@ const (
 )
 
 const (
-	// noShareInsertion indicates that a new share hasn't been inserted in the eds
-	noShareInsertion = -1
+	// noChunkInsertion indicates that a new chunk hasn't been inserted in the EDS
+	noChunkInsertion = -1
 )
 
 func (a Axis) String() string {
@@ -44,11 +44,12 @@ type ErrByzantineData struct {
 	Axis Axis
 	// Index is the row or column index.
 	Index uint
-	// Shares contain the shares in the row or column that the client can
-	// determine proofs for (either through sampling or using shares decoded
-	// from the extended data square). In other words, it contains shares whose
-	// individual inclusion is guaranteed to be provable by the full node (i.e.
-	// shares usable in a bad encoding fraud proof). Missing shares are nil.
+	// Shares (a.k.a chunks) contain the shares in the row or column that the
+	// client can determine proofs for (either through sampling or using shares
+	// decoded from the extended data square). In other words, it contains
+	// shares whose individual inclusion is guaranteed to be provable by the
+	// full node (i.e. shares usable in a bad encoding fraud proof). Missing
+	// shares are nil.
 	Shares [][]byte
 }
 
@@ -62,14 +63,14 @@ func (e *ErrByzantineData) Error() string {
 // and column. rowRoots and colRoots are used to verify that a repaired row or
 // column is correct. Prior to the repair process, if a row or column is already
 // complete but the Merkle root for the row or column doesn't match the expected
-// root, an error is returned. Missing shares in the EDS must be nil.
+// root, an error is returned. Missing chunks in the EDS must be nil.
 //
 // # Output
 //
 // The EDS is modified in-place. If repairing is successful, the EDS will be
 // complete. If repairing is unsuccessful, the EDS will be the most-repaired
 // prior to the Byzantine row or column being repaired, and the Byzantine row
-// or column prior to repair is returned in the error with missing shares as
+// or column prior to repair is returned in the error with missing chunks as
 // nil.
 func (eds *ExtendedDataSquare) Repair(
 	rowRoots [][]byte,
@@ -131,20 +132,20 @@ func (eds *ExtendedDataSquare) solveCrosswordRow(
 	rowRoots [][]byte,
 	colRoots [][]byte,
 ) (bool, bool, error) {
-	isComplete := noMissingData(eds.row(uint(r)), noShareInsertion)
+	isComplete := noMissingData(eds.row(uint(r)), noChunkInsertion)
 	if isComplete {
 		return true, false, nil
 	}
 
-	// Prepare shares
-	shares := make([][]byte, eds.width)
+	// Prepare chunks
+	chunks := make([][]byte, eds.width)
 	vectorData := eds.row(uint(r))
 	for c := 0; c < int(eds.width); c++ {
-		shares[c] = vectorData[c]
+		chunks[c] = vectorData[c]
 	}
 
 	// Attempt rebuild the row
-	rebuiltShares, isDecoded, err := eds.rebuildShares(shares)
+	rebuiltChunks, isDecoded, err := eds.rebuildChunks(chunks)
 	if err != nil {
 		return false, false, err
 	}
@@ -152,12 +153,12 @@ func (eds *ExtendedDataSquare) solveCrosswordRow(
 		return false, false, nil
 	}
 
-	// Check that rebuilt shares matches appropriate root
-	err = eds.verifyAgainstRowRoots(rowRoots, uint(r), rebuiltShares, noShareInsertion, nil)
+	// Check that rebuilt chunks matches appropriate root
+	err = eds.verifyAgainstRowRoots(rowRoots, uint(r), rebuiltChunks, noChunkInsertion, nil)
 	if err != nil {
 		var byzErr *ErrByzantineData
 		if errors.As(err, &byzErr) {
-			byzErr.Shares = shares
+			byzErr.Shares = chunks
 		}
 		return false, false, err
 	}
@@ -169,19 +170,19 @@ func (eds *ExtendedDataSquare) solveCrosswordRow(
 			continue // not newly completed
 		}
 		if noMissingData(col, r) { // completed
-			err := eds.verifyAgainstColRoots(colRoots, uint(c), col, r, rebuiltShares[c])
+			err := eds.verifyAgainstColRoots(colRoots, uint(c), col, r, rebuiltChunks[c])
 			if err != nil {
 				var byzErr *ErrByzantineData
 				if errors.As(err, &byzErr) {
-					byzErr.Shares = shares
+					byzErr.Shares = chunks
 				}
 				return false, false, err
 			}
 		}
 	}
 
-	// Insert rebuilt shares into square.
-	for c, s := range rebuiltShares {
+	// Insert rebuilt chunks into square.
+	for c, s := range rebuiltChunks {
 		cellToSet := eds.GetCell(uint(r), uint(c))
 		if cellToSet == nil {
 			err := eds.SetCell(uint(r), uint(c), s)
@@ -204,20 +205,20 @@ func (eds *ExtendedDataSquare) solveCrosswordCol(
 	rowRoots [][]byte,
 	colRoots [][]byte,
 ) (bool, bool, error) {
-	isComplete := noMissingData(eds.col(uint(c)), noShareInsertion)
+	isComplete := noMissingData(eds.col(uint(c)), noChunkInsertion)
 	if isComplete {
 		return true, false, nil
 	}
 
-	// Prepare shares
-	shares := make([][]byte, eds.width)
+	// Prepare chunks
+	chunks := make([][]byte, eds.width)
 	vectorData := eds.col(uint(c))
 	for r := 0; r < int(eds.width); r++ {
-		shares[r] = vectorData[r]
+		chunks[r] = vectorData[r]
 	}
 
 	// Attempt rebuild
-	rebuiltShares, isDecoded, err := eds.rebuildShares(shares)
+	rebuiltChunks, isDecoded, err := eds.rebuildChunks(chunks)
 	if err != nil {
 		return false, false, err
 	}
@@ -225,12 +226,12 @@ func (eds *ExtendedDataSquare) solveCrosswordCol(
 		return false, false, nil
 	}
 
-	// Check that rebuilt shares matches appropriate root
-	err = eds.verifyAgainstColRoots(colRoots, uint(c), rebuiltShares, noShareInsertion, nil)
+	// Check that rebuilt chunks matches appropriate root
+	err = eds.verifyAgainstColRoots(colRoots, uint(c), rebuiltChunks, noChunkInsertion, nil)
 	if err != nil {
 		var byzErr *ErrByzantineData
 		if errors.As(err, &byzErr) {
-			byzErr.Shares = shares
+			byzErr.Shares = chunks
 		}
 		return false, false, err
 	}
@@ -242,19 +243,19 @@ func (eds *ExtendedDataSquare) solveCrosswordCol(
 			continue // not newly completed
 		}
 		if noMissingData(row, c) { // completed
-			err := eds.verifyAgainstRowRoots(rowRoots, uint(r), row, c, rebuiltShares[r])
+			err := eds.verifyAgainstRowRoots(rowRoots, uint(r), row, c, rebuiltChunks[r])
 			if err != nil {
 				var byzErr *ErrByzantineData
 				if errors.As(err, &byzErr) {
-					byzErr.Shares = shares
+					byzErr.Shares = chunks
 				}
 				return false, false, err
 			}
 		}
 	}
 
-	// Insert rebuilt shares into square.
-	for r, s := range rebuiltShares {
+	// Insert rebuilt chunks into square.
+	for r, s := range rebuiltChunks {
 		cellToSet := eds.GetCell(uint(r), uint(c))
 		if cellToSet == nil {
 			err := eds.SetCell(uint(r), uint(c), s)
@@ -267,37 +268,35 @@ func (eds *ExtendedDataSquare) solveCrosswordCol(
 	return true, true, nil
 }
 
-// rebuildShares attempts to rebuild a row or column of shares.
+// rebuildChunks attempts to rebuild a row or column of chunks.
 // Returns
-// 1. An entire row or column of shares so original + parity shares.
-// 2. Whether the original shares could be decoded from the shares parameter.
+// 1. An entire row or column of chunks so original + parity chunks.
+// 2. Whether the original chunks could be decoded from the chunks parameter.
 // 3. [Optional] an error.
-func (eds *ExtendedDataSquare) rebuildShares(
-	shares [][]byte,
-) ([][]byte, bool, error) {
-	rebuiltShares, err := eds.codec.Decode(shares)
+func (eds *ExtendedDataSquare) rebuildChunks(chunks [][]byte) ([][]byte, bool, error) {
+	rebuiltChunks, err := eds.codec.Decode(chunks)
 	if err != nil {
 		// Decode was unsuccessful but don't propagate the error because that
 		// would halt the progress of solveCrosswordRow or solveCrosswordCol.
 		return nil, false, nil
 	}
 
-	return rebuiltShares, true, nil
+	return rebuiltChunks, true, nil
 }
 
 func (eds *ExtendedDataSquare) verifyAgainstRowRoots(
 	rowRoots [][]byte,
 	r uint,
-	oldShares [][]byte,
+	oldChunks [][]byte,
 	rebuiltIndex int,
-	rebuiltShare []byte,
+	rebuiltChunk []byte,
 ) error {
 	var root []byte
 	var err error
-	if rebuiltIndex < 0 || rebuiltShare == nil {
-		root, err = eds.computeSharesRoot(oldShares, Row, r)
+	if rebuiltIndex < 0 || rebuiltChunk == nil {
+		root, err = eds.computeChunksRoot(oldChunks, Row, r)
 	} else {
-		root, err = eds.computeSharesRootWithRebuiltShare(oldShares, Row, r, rebuiltIndex, rebuiltShare)
+		root, err = eds.computeChunksRootWithRebuiltChunk(oldChunks, Row, r, rebuiltIndex, rebuiltChunk)
 	}
 	if err != nil {
 		// any error during the computation of the root is considered byzantine
@@ -313,34 +312,34 @@ func (eds *ExtendedDataSquare) verifyAgainstRowRoots(
 	return nil
 }
 
-// verifyAgainstColRoots checks that the shares of column index `c` match their expected column root available in `colRoots`.
-// `colRoots` is a slice of the expected roots of the columns of the `eds`.
-// `shares` is a slice of the shares of the column index `c` of the `eds`.
-// `rebuiltIndex` is the index of the share that was rebuilt, if any.
-// `rebuiltShare` is the rebuilt share, if any.
+// verifyAgainstColRoots checks that the chunks of columnIndex match their expected column root in colRoots.
+// colRoots is a slice of the expected eds column roots.
+// chunks is a slice of the chunks of the columnIndex of the eds.
+// rebuiltIndex is the index of the chunk that was rebuilt, if any.
+// rebuiltChunk is the rebuilt chunk, if any.
 // Returns a ErrByzantineData error if the computed root does not match the expected root or if the root computation fails.
 func (eds *ExtendedDataSquare) verifyAgainstColRoots(
 	colRoots [][]byte,
-	c uint,
-	shares [][]byte,
+	columnIndex uint,
+	chunks [][]byte,
 	rebuiltIndex int,
-	rebuiltShare []byte,
+	rebuiltChunk []byte,
 ) error {
 	var root []byte
 	var err error
-	if rebuiltIndex < 0 || rebuiltShare == nil {
-		root, err = eds.computeSharesRoot(shares, Col, c)
+	if rebuiltIndex < 0 || rebuiltChunk == nil {
+		root, err = eds.computeChunksRoot(chunks, Col, columnIndex)
 	} else {
-		root, err = eds.computeSharesRootWithRebuiltShare(shares, Col, c, rebuiltIndex, rebuiltShare)
+		root, err = eds.computeChunksRootWithRebuiltChunk(chunks, Col, columnIndex, rebuiltIndex, rebuiltChunk)
 	}
 	if err != nil {
 		// the shares are set to nil, as the caller will populate them
-		return &ErrByzantineData{Col, c, nil}
+		return &ErrByzantineData{Col, columnIndex, nil}
 	}
 
-	if !bytes.Equal(root, colRoots[c]) {
+	if !bytes.Equal(root, colRoots[columnIndex]) {
 		// the shares are set to nil, as the caller will populate them
-		return &ErrByzantineData{Col, c, nil}
+		return &ErrByzantineData{Col, columnIndex, nil}
 	}
 
 	return nil
@@ -358,7 +357,7 @@ func (eds *ExtendedDataSquare) preRepairSanityCheck(
 	for i := uint(0); i < eds.width; i++ {
 		i := i
 
-		rowIsComplete := noMissingData(eds.row(i), noShareInsertion)
+		rowIsComplete := noMissingData(eds.row(i), noChunkInsertion)
 		// if there's no missing data in this row
 		if rowIsComplete {
 			errs.Go(func() error {
@@ -376,18 +375,18 @@ func (eds *ExtendedDataSquare) preRepairSanityCheck(
 				return nil
 			})
 			errs.Go(func() error {
-				parityShares, err := eds.codec.Encode(eds.rowSlice(i, 0, eds.originalDataWidth))
+				parityChunks, err := eds.codec.Encode(eds.rowSlice(i, 0, eds.originalDataWidth))
 				if err != nil {
 					return err
 				}
-				if !bytes.Equal(flattenChunks(parityShares), flattenChunks(eds.rowSlice(i, eds.originalDataWidth, eds.originalDataWidth))) {
+				if !bytes.Equal(flattenChunks(parityChunks), flattenChunks(eds.rowSlice(i, eds.originalDataWidth, eds.originalDataWidth))) {
 					return &ErrByzantineData{Row, i, eds.row(i)}
 				}
 				return nil
 			})
 		}
 
-		colIsComplete := noMissingData(eds.col(i), noShareInsertion)
+		colIsComplete := noMissingData(eds.col(i), noChunkInsertion)
 		// if there's no missing data in this col
 		if colIsComplete {
 			errs.Go(func() error {
@@ -406,11 +405,11 @@ func (eds *ExtendedDataSquare) preRepairSanityCheck(
 			})
 			errs.Go(func() error {
 				// check if we take the first half of the col and encode it, we get the second half
-				parityShares, err := eds.codec.Encode(eds.colSlice(0, i, eds.originalDataWidth))
+				parityChunks, err := eds.codec.Encode(eds.colSlice(0, i, eds.originalDataWidth))
 				if err != nil {
 					return err
 				}
-				if !bytes.Equal(flattenChunks(parityShares), flattenChunks(eds.colSlice(eds.originalDataWidth, i, eds.originalDataWidth))) {
+				if !bytes.Equal(flattenChunks(parityChunks), flattenChunks(eds.colSlice(eds.originalDataWidth, i, eds.originalDataWidth))) {
 					return &ErrByzantineData{Col, i, eds.col(i)}
 				}
 				return nil
@@ -433,10 +432,10 @@ func noMissingData(input [][]byte, rebuiltIndex int) bool {
 	return true
 }
 
-// computeSharesRoot calculates the root of the shares for the specified axis (`i`th column or row).
-func (eds *ExtendedDataSquare) computeSharesRoot(shares [][]byte, axis Axis, i uint) ([]byte, error) {
+// computeChunksRoot calculates the root of the chunks for the specified axis (`i`th column or row).
+func (eds *ExtendedDataSquare) computeChunksRoot(chunks [][]byte, axis Axis, i uint) ([]byte, error) {
 	tree := eds.createTreeFn(axis, i)
-	for _, d := range shares {
+	for _, d := range chunks {
 		err := tree.Push(d)
 		if err != nil {
 			return nil, err
@@ -445,22 +444,22 @@ func (eds *ExtendedDataSquare) computeSharesRoot(shares [][]byte, axis Axis, i u
 	return tree.Root()
 }
 
-// computeSharesRootWithRebuiltShare computes the root of the shares with the rebuilt share `rebuiltShare` at the specified index `rebuiltIndex`.
-func (eds *ExtendedDataSquare) computeSharesRootWithRebuiltShare(shares [][]byte, axis Axis, i uint, rebuiltIndex int, rebuiltShare []byte) ([]byte, error) {
+// computeChunksRootWithRebuiltChunk computes the root of the chunks with the rebuilt chunk `rebuiltChunk` at the specified index `rebuiltIndex`.
+func (eds *ExtendedDataSquare) computeChunksRootWithRebuiltChunk(chunks [][]byte, axis Axis, i uint, rebuiltIndex int, rebuiltChunk []byte) ([]byte, error) {
 	tree := eds.createTreeFn(axis, i)
-	for _, d := range shares[:rebuiltIndex] {
+	for _, d := range chunks[:rebuiltIndex] {
 		err := tree.Push(d)
 		if err != nil {
 			return nil, err
 		}
 	}
 
-	err := tree.Push(rebuiltShare)
+	err := tree.Push(rebuiltChunk)
 	if err != nil {
 		return nil, err
 	}
 
-	for _, d := range shares[rebuiltIndex+1:] {
+	for _, d := range chunks[rebuiltIndex+1:] {
 		err := tree.Push(d)
 		if err != nil {
 			return nil, err

--- a/extendeddatasquare.go
+++ b/extendeddatasquare.go
@@ -107,7 +107,7 @@ func ImportExtendedDataSquare(
 }
 
 // NewExtendedDataSquare returns a new extended data square with a width of
-// edsWidth. All shares are initialized to nil so that the returned extended
+// edsWidth. All chunks are initialized to nil so that the returned extended
 // data square can be populated via subsequent SetCell invocations.
 func NewExtendedDataSquare(codec Codec, treeCreatorFn TreeConstructorFn, edsWidth uint, chunkSize uint) (*ExtendedDataSquare, error) {
 	err := validateEdsWidth(edsWidth)
@@ -210,19 +210,19 @@ func (eds *ExtendedDataSquare) erasureExtendSquare(codec Codec) error {
 }
 
 func (eds *ExtendedDataSquare) erasureExtendRow(codec Codec, i uint) error {
-	parityShares, err := codec.Encode(eds.rowSlice(i, 0, eds.originalDataWidth))
+	parityChunks, err := codec.Encode(eds.rowSlice(i, 0, eds.originalDataWidth))
 	if err != nil {
 		return err
 	}
-	return eds.setRowSlice(i, eds.originalDataWidth, parityShares)
+	return eds.setRowSlice(i, eds.originalDataWidth, parityChunks)
 }
 
 func (eds *ExtendedDataSquare) erasureExtendCol(codec Codec, i uint) error {
-	parityShares, err := codec.Encode(eds.colSlice(0, i, eds.originalDataWidth))
+	parityChunks, err := codec.Encode(eds.colSlice(0, i, eds.originalDataWidth))
 	if err != nil {
 		return err
 	}
-	return eds.setColSlice(eds.originalDataWidth, i, parityShares)
+	return eds.setColSlice(eds.originalDataWidth, i, parityChunks)
 }
 
 func (eds *ExtendedDataSquare) deepCopy(codec Codec) (ExtendedDataSquare, error) {
@@ -237,7 +237,7 @@ func (eds *ExtendedDataSquare) Col(y uint) [][]byte {
 }
 
 // ColRoots returns the Merkle roots of all the columns in the square. Returns
-// an error if the EDS is incomplete (i.e. some shares are nil).
+// an error if the EDS is incomplete (i.e. some chunks are nil).
 func (eds *ExtendedDataSquare) ColRoots() ([][]byte, error) {
 	colRoots, err := eds.getColRoots()
 	if err != nil {
@@ -253,7 +253,7 @@ func (eds *ExtendedDataSquare) Row(x uint) [][]byte {
 }
 
 // RowRoots returns the Merkle roots of all the rows in the square. Returns an
-// error if the EDS is incomplete (i.e. some shares are nil).
+// error if the EDS is incomplete (i.e. some chunks are nil).
 func (eds *ExtendedDataSquare) RowRoots() ([][]byte, error) {
 	rowRoots, err := eds.getRowRoots()
 	if err != nil {

--- a/leopard.go
+++ b/leopard.go
@@ -32,16 +32,16 @@ func (l *LeoRSCodec) Encode(data [][]byte) ([][]byte, error) {
 		return nil, err
 	}
 
-	shards := make([][]byte, dataLen*2)
-	copy(shards, data)
-	for i := dataLen; i < len(shards); i++ {
-		shards[i] = make([]byte, len(data[0]))
+	chunks := make([][]byte, dataLen*2)
+	copy(chunks, data)
+	for i := dataLen; i < len(chunks); i++ {
+		chunks[i] = make([]byte, len(data[0]))
 	}
 
-	if err := enc.Encode(shards); err != nil {
+	if err := enc.Encode(chunks); err != nil {
 		return nil, err
 	}
-	return shards[dataLen:], nil
+	return chunks[dataLen:], nil
 }
 
 func (l *LeoRSCodec) Decode(data [][]byte) ([][]byte, error) {

--- a/rsmt2d_test.go
+++ b/rsmt2d_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// shareSize is the size of each share (in bytes) used for testing.
-const shareSize = 512
+// chunkSize is the size of each chunk (in bytes) used for testing.
+const chunkSize = 512
 
 func TestEdsRepairRoundtripSimple(t *testing.T) {
 	tests := []struct {
@@ -23,12 +23,12 @@ func TestEdsRepairRoundtripSimple(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ones := bytes.Repeat([]byte{1}, shareSize)
-			twos := bytes.Repeat([]byte{2}, shareSize)
-			threes := bytes.Repeat([]byte{3}, shareSize)
-			fours := bytes.Repeat([]byte{4}, shareSize)
+			ones := bytes.Repeat([]byte{1}, chunkSize)
+			twos := bytes.Repeat([]byte{2}, chunkSize)
+			threes := bytes.Repeat([]byte{3}, chunkSize)
+			fours := bytes.Repeat([]byte{4}, chunkSize)
 
-			// Compute parity shares
+			// Compute parity chunks
 			eds, err := rsmt2d.ComputeExtendedDataSquare(
 				[][]byte{
 					ones, twos,
@@ -49,7 +49,7 @@ func TestEdsRepairRoundtripSimple(t *testing.T) {
 
 			flattened := eds.Flattened()
 
-			// Delete some shares, just enough so that repairing is possible.
+			// Delete some chunks, just enough so that repairing is possible.
 			flattened[0], flattened[2], flattened[3] = nil, nil, nil
 			flattened[4], flattened[5], flattened[6], flattened[7] = nil, nil, nil, nil
 			flattened[8], flattened[9], flattened[10] = nil, nil, nil
@@ -85,12 +85,12 @@ func TestEdsRepairTwice(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ones := bytes.Repeat([]byte{1}, shareSize)
-			twos := bytes.Repeat([]byte{2}, shareSize)
-			threes := bytes.Repeat([]byte{3}, shareSize)
-			fours := bytes.Repeat([]byte{4}, shareSize)
+			ones := bytes.Repeat([]byte{1}, chunkSize)
+			twos := bytes.Repeat([]byte{2}, chunkSize)
+			threes := bytes.Repeat([]byte{3}, chunkSize)
+			fours := bytes.Repeat([]byte{4}, chunkSize)
 
-			// Compute parity shares
+			// Compute parity chunks
 			eds, err := rsmt2d.ComputeExtendedDataSquare(
 				[][]byte{
 					ones, twos,
@@ -111,8 +111,8 @@ func TestEdsRepairTwice(t *testing.T) {
 
 			flattened := eds.Flattened()
 
-			// Delete some shares, just enough so that repairing is possible, then remove one more.
-			missing := make([]byte, shareSize)
+			// Delete some chunks, just enough so that repairing is possible, then remove one more.
+			missing := make([]byte, chunkSize)
 			copy(missing, flattened[1])
 			flattened[0], flattened[1], flattened[2], flattened[3] = nil, nil, nil, nil
 			flattened[4], flattened[5], flattened[6], flattened[7] = nil, nil, nil, nil
@@ -134,8 +134,8 @@ func TestEdsRepairTwice(t *testing.T) {
 				// Should fail since insufficient data.
 				t.Errorf("RepairExtendedDataSquare did not fail with `%v`, got `%v`", rsmt2d.ErrUnrepairableDataSquare, err)
 			}
-			// Re-insert missing share and try again.
-			flattened[1] = make([]byte, shareSize)
+			// Re-insert missing chunks and try again.
+			flattened[1] = make([]byte, chunkSize)
 			copy(flattened[1], missing)
 
 			// Re-import the data square.


### PR DESCRIPTION
Closes https://github.com/celestiaorg/rsmt2d/issues/215

I opted to use chunk instead of share because @musalbas preferred it and chunk already appears in the exported API of this library (e.g. `ValidateChunkSize`, `MaxChunks`). 

Technically `Shares` is in the public API too (it's a field of `ErrByzantineData`) but this PR doesn't introduce any breaking changes b/c IMO it's not worth breaking API over this name change.