### PR TITLE
test: extends computeRoots benchmark to cover larger square sizes and nmt tree

### DIFF
--- a/datasquare_test.go
+++ b/datasquare_test.go
@@ -423,7 +423,7 @@ func BenchmarkEDSRootsWithDefaultTree(b *testing.B) {
 }
 
 func BenchmarkEDSRootsWithErasuredNMT(b *testing.B) {
-	ODSSizeByteUpperBound := 1024 * 1024 * 1024 // converting 512 MB to bytes
+	ODSSizeByteUpperBound := 1024 * 1024 * 1024 // converting 512 MiB to bytes
 	totalNumberOfShares := float64(ODSSizeByteUpperBound) / shareSize
 	// the closest power of 2 of the square root of
 	// the total number of shares

--- a/datasquare_test.go
+++ b/datasquare_test.go
@@ -403,7 +403,26 @@ func Test_setColSlice(t *testing.T) {
 	}
 }
 
-func BenchmarkEDSRoots(b *testing.B) {
+func BenchmarkEDSRootsWithDefaultTree(b *testing.B) {
+	for i := 32; i < 513; i *= 2 {
+		square, err := newDataSquare(genRandDS(i*2, int(shareSize)), NewDefaultTree, shareSize)
+		if err != nil {
+			b.Errorf("Failure to create square of size %d: %s", i, err)
+		}
+		b.Run(
+			fmt.Sprintf("%dx%dx%d ODS", i, i, int(square.chunkSize)),
+			func(b *testing.B) {
+				for n := 0; n < b.N; n++ {
+					square.resetRoots()
+					err := square.computeRoots()
+					assert.NoError(b, err)
+				}
+			},
+		)
+	}
+}
+
+func BenchmarkEDSRootsWithErasuredNMT(b *testing.B) {
 	ODSSizeByteUpperBound := 1024 * 1024 * 1024 // converting 1024 MB to bytes
 	totalNumberOfShares := ODSSizeByteUpperBound / shareSize
 	oDSShareSizeUpperBound := int(math.Ceil(math.Sqrt(float64(

--- a/datasquare_test.go
+++ b/datasquare_test.go
@@ -427,11 +427,11 @@ func BenchmarkEDSRootsWithErasuredNMT(b *testing.B) {
 	totalNumberOfShares := float64(ODSSizeByteUpperBound) / shareSize
 	// the closest power of 2 of the square root of
 	// the total number of shares
-	oDSShareSizeUpperBound := math.Pow(2, math.Ceil(math.Log2(math.Sqrt(
+	nearestPowerOf2ODSSize := math.Pow(2, math.Ceil(math.Log2(math.Sqrt(
 		totalNumberOfShares))))
 	namespaceIDSize := 29
 
-	for i := 32; i <= int(oDSShareSizeUpperBound); i *= 2 {
+	for i := 32; i <= int(nearestPowerOf2ODSSize); i *= 2 {
 		// number of shares in the original data square's row/column
 		odsSize := i
 		// number of shares in the extended data square's row/column

--- a/datasquare_test.go
+++ b/datasquare_test.go
@@ -451,7 +451,9 @@ func BenchmarkEDSRootsWithErasuredNMT(b *testing.B) {
 		if err != nil {
 			b.Errorf("Failure to create square of size %d: %s", i, err)
 		}
-		odsSizeMiBytes := i * i * shareSize / (1024 * 1024) // size in MiB
+		// the total size of the ODS in MiB
+		odsSizeMiBytes := i * i * shareSize / (1024 * 1024)
+		// the total size of the EDS in MiB
 		edsSizeMiBytes := 4 * odsSizeMiBytes
 		b.Run(
 			fmt.Sprintf("%dx%dx%d ODS=%dMB, EDS=%dMB", i, i,

--- a/datasquare_test.go
+++ b/datasquare_test.go
@@ -423,17 +423,20 @@ func BenchmarkEDSRootsWithDefaultTree(b *testing.B) {
 }
 
 func BenchmarkEDSRootsWithErasuredNMT(b *testing.B) {
-	ODSSizeByteUpperBound := 1024 * 1024 * 1024 // converting 1024 MB to bytes
-	totalNumberOfShares := ODSSizeByteUpperBound / shareSize
-	oDSShareSizeUpperBound := int(math.Ceil(math.Sqrt(float64(
+	ODSSizeByteUpperBound := 1024 * 1024 * 1024 // converting 512 MB to bytes
+	totalNumberOfShares := float64(ODSSizeByteUpperBound) / shareSize
+	// the closest power of 2 of the square root of
+	// the total number of shares
+	oDSShareSizeUpperBound := math.Pow(2, math.Ceil(math.Log2(math.Sqrt(
 		totalNumberOfShares))))
 	namespaceIDSize := 29
-	for i := 32; i < oDSShareSizeUpperBound; i *= 2 {
+
+	for i := 32; i <= int(oDSShareSizeUpperBound); i *= 2 {
 		// generate an EDS with i*2 X i*2 dimensions in terms of shares
 		// the generated EDS does not conform to celestia-app specs in terms
-		// of namespace version, also  no  erasure encoding takes place
-		// yet none of these would affect the benchmarking
-		ds := genRandSortedDS(i*2, shareSize, 29)
+		// of namespace version, also no erasure encoding takes place
+		// yet none of these should impact the benchmarking
+		ds := genRandSortedDS(i*2, shareSize, namespaceIDSize)
 
 		// a tree constructor for erasured nmt
 		treeConstructor := newErasuredNamespacedMerkleTreeConstructor(uint64(i*2),
@@ -447,8 +450,8 @@ func BenchmarkEDSRootsWithErasuredNMT(b *testing.B) {
 		b.Run(
 			fmt.Sprintf("%dx%dx%d ODS=%dMB, EDS=%dMB", i, i,
 				int(square.chunkSize),
-				i*i*512/(1024*1024),
-				2*2*i*i*512/(1024*1024)),
+				i*i*shareSize/(1024*1024),
+				2*i*2*i*shareSize/(1024*1024)),
 			func(b *testing.B) {
 				for n := 0; n < b.N; n++ {
 					square.resetRoots()

--- a/extendeddatacrossword_test.go
+++ b/extendeddatacrossword_test.go
@@ -439,7 +439,7 @@ func createTestEdsWithNMT(t *testing.T, codec Codec, shareSize, namespaceSize in
 	edsWidth := 4            // number of shares per row/column in the extended data square
 	odsWidth := edsWidth / 2 // number of shares per row/column in the original data square
 
-	eds, err := ComputeExtendedDataSquare(shares, codec, newConstructor(uint64(odsWidth), nmt.NamespaceIDSize(namespaceSize)))
+	eds, err := ComputeExtendedDataSquare(shares, codec, newErasuredNamespacedMerkleTreeConstructor(uint64(odsWidth), nmt.NamespaceIDSize(namespaceSize)))
 	require.NoError(t, err)
 
 	return eds

--- a/extendeddatasquare_test.go
+++ b/extendeddatasquare_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
+	"sort"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -345,6 +346,20 @@ func genRandDS(width int, chunkSize int) [][]byte {
 		ds = append(ds, share)
 	}
 	return ds
+}
+
+func genRandSortedDS(width int, chunkSize int, namespaceSize int) [][]byte {
+
+	ds := genRandDS(width, chunkSize)
+
+	// Sort the shares in the square based on their namespace
+	sort.Slice(ds, func(i, j int) bool {
+		// Compare only the first  namespaceSize bytes
+		return bytes.Compare(ds[i][:namespaceSize], ds[j][:namespaceSize]) < 0
+	})
+
+	return ds
+
 }
 
 // TestFlattened_EDS tests that eds.Flattened() returns all the shares in the

--- a/extendeddatasquare_test.go
+++ b/extendeddatasquare_test.go
@@ -349,7 +349,6 @@ func genRandDS(width int, chunkSize int) [][]byte {
 }
 
 func genRandSortedDS(width int, chunkSize int, namespaceSize int) [][]byte {
-
 	ds := genRandDS(width, chunkSize)
 
 	// Sort the shares in the square based on their namespace
@@ -359,7 +358,6 @@ func genRandSortedDS(width int, chunkSize int, namespaceSize int) [][]byte {
 	})
 
 	return ds
-
 }
 
 // TestFlattened_EDS tests that eds.Flattened() returns all the shares in the

--- a/nmtwrapper_test.go
+++ b/nmtwrapper_test.go
@@ -54,7 +54,8 @@ type nmtTree interface {
 // with an underlying NMT of namespace size `NamespaceSize` and with
 // `ignoreMaxNamespace=true`. axisIndex is the index of the row or column that
 // this tree is committing to. squareSize must be greater than zero.
-func newErasuredNamespacedMerkleTree(squareSize uint64, axisIndex uint, options ...nmt.Option) erasuredNamespacedMerkleTree {
+func newErasuredNamespacedMerkleTree(squareSize uint64, axisIndex uint,
+	options ...nmt.Option) erasuredNamespacedMerkleTree {
 	if squareSize == 0 {
 		panic("cannot create a erasuredNamespacedMerkleTree of squareSize == 0")
 	}
@@ -73,10 +74,10 @@ type constructor struct {
 	opts       []nmt.Option
 }
 
-// newConstructor creates a tree constructor function as required by rsmt2d to
+// newErasuredNamespacedMerkleTreeConstructor creates a tree constructor function as required by rsmt2d to
 // calculate the data root. It creates that tree using the
 // erasuredNamespacedMerkleTree.
-func newConstructor(squareSize uint64, opts ...nmt.Option) TreeConstructorFn {
+func newErasuredNamespacedMerkleTreeConstructor(squareSize uint64, opts ...nmt.Option) TreeConstructorFn {
 	return constructor{
 		squareSize: squareSize,
 		opts:       opts,

--- a/nmtwrapper_test.go
+++ b/nmtwrapper_test.go
@@ -55,7 +55,8 @@ type nmtTree interface {
 // `ignoreMaxNamespace=true`. axisIndex is the index of the row or column that
 // this tree is committing to. squareSize must be greater than zero.
 func newErasuredNamespacedMerkleTree(squareSize uint64, axisIndex uint,
-	options ...nmt.Option) erasuredNamespacedMerkleTree {
+	options ...nmt.Option,
+) erasuredNamespacedMerkleTree {
 	if squareSize == 0 {
 		panic("cannot create a erasuredNamespacedMerkleTree of squareSize == 0")
 	}


### PR DESCRIPTION
Closes #303 