### PR TITLE
fix: deepcopy filliing nil data with zeroes

### DIFF
--- a/extendeddatasquare.go
+++ b/extendeddatasquare.go
@@ -267,6 +267,9 @@ func (eds *ExtendedDataSquare) RowRoots() ([][]byte, error) {
 func deepCopy(original [][]byte) [][]byte {
 	dest := make([][]byte, len(original))
 	for i, cell := range original {
+		if cell == nil {
+			continue
+		}
 		dest[i] = make([]byte, len(cell))
 		copy(dest[i], cell)
 	}

--- a/extendeddatasquare_test.go
+++ b/extendeddatasquare_test.go
@@ -482,6 +482,23 @@ func TestRoots(t *testing.T) {
 	})
 }
 
+func TestDeepCopy(t *testing.T) {
+	original := make([][]byte, 16)
+	// fill first 8 shares with random data, leave the rest nil
+	for i := range original[:8] {
+		original[i] = make([]byte, 4)
+		_, err := rand.Read(original[i])
+		require.NoError(t, err)
+	}
+
+	copied := deepCopy(original)
+	require.Equal(t, original, copied)
+
+	// modify the original and ensure the copy is not affected
+	original[0][0]++
+	require.NotEqual(t, original, copied)
+}
+
 func createExampleEds(t *testing.T, shareSize int) (eds *ExtendedDataSquare) {
 	ones := bytes.Repeat([]byte{1}, shareSize)
 	twos := bytes.Repeat([]byte{2}, shareSize)


### PR DESCRIPTION
Corrects the bug introduced by https://github.com/celestiaorg/rsmt2d/pull/100. Currently, if `deepcopy()` encounters nil inner slice values, it creates a slice of 0 length, which is incorrect. This PR addresses the issue. The problem becomes evident when eds is partially computed, resulting in Row() or Col() methods returning invalid copies.

On the side note, it is technically breaking public API change. But the nature of the bug suggests noone relied on existing misbehaviour before.