### PR TITLE
test: add randomized tests for errByzantine

### DIFF
--- a/extendeddatacrossword_test.go
+++ b/extendeddatacrossword_test.go
@@ -491,9 +491,9 @@ func repairNewFromCorrupted(codec Codec, corrupted *ExtendedDataSquare, corrupte
 	}
 
 	// set corrupted share first
-	errX, errY := corruptedIdx/int(corrupted.Width()), corruptedIdx%int(corrupted.Width())
-	share := corrupted.GetCell(uint(errX), uint(errY))
-	err = square.SetCell(uint(errX), uint(errY), share)
+	corruptedX, corruptedY := corruptedIdx/int(corrupted.Width()), corruptedIdx%int(corrupted.Width())
+	share := corrupted.GetCell(uint(corruptedX), uint(corruptedY))
+	err = square.SetCell(uint(corruptedX), uint(corruptedY), share)
 	if err != nil {
 		return nil, fmt.Errorf("failure to set corrupted share: %w", err)
 	}
@@ -516,7 +516,7 @@ func repairNewFromCorrupted(codec Codec, corrupted *ExtendedDataSquare, corrupte
 		}
 		var errByz *ErrByzantineData
 		if errors.As(err, &errByz) {
-			err = checkErrByzantine(errByz, errX, errY)
+			err = checkErrByzantine(errByz, corruptedX, corruptedY)
 			if err != nil {
 				prettyPrintSamples(samples, corruptedIdx)
 			}


### PR DESCRIPTION
ErrByzantine encompasses numerous edge cases. To address this, I implemented randomized fuzzing tests, which identified instances where shares encoding was not properly verified. 

While I am neutral about maintaining the pretty printing code (as it looks kinda off), I retained it because it proved extremely useful for understanding the reasons behind test failures during extensive debugging. Should these tests fail in the future for any reason, having a visual representation of the issues will expedite debugging for future developers.

Allowed to discover https://github.com/celestiaorg/rsmt2d/pull/313