### PR TITLE
fix: verify encoding of shares in case when axis is fully reconstructed from orthogonal

### DIFF
--- a/extendeddatacrossword.go
+++ b/extendeddatacrossword.go
@@ -471,6 +471,7 @@ func (eds *ExtendedDataSquare) computeSharesRootWithRebuiltShare(shares [][]byte
 	return tree.Root()
 }
 
+// verifyEncoding checks the Reed-Solomon encoding of the provided data.
 func (eds *ExtendedDataSquare) verifyEncoding(data [][]byte, rebuiltIndex int, rebuiltShare []byte) error {
 	data[rebuiltIndex] = rebuiltShare
 	half := len(data) / 2


### PR DESCRIPTION
If axis is fully recomputed from orthogonal axises, we need to verify correct encoding on top of verification of roots.
Test coverage should happen by https://github.com/celestiaorg/rsmt2d/pull/312