### PR TITLE
refactor: use deepCopy for eds.Flattened()

### DIFF
--- a/datasquare.go
+++ b/datasquare.go
@@ -335,7 +335,7 @@ func (ds *dataSquare) SetCell(x uint, y uint, newShare []byte) error {
 
 // Flattened returns the concatenated rows of the data square.
 func (ds *dataSquare) Flattened() [][]byte {
-	flattened := [][]byte(nil)
+	flattened := make([][]byte, 0, ds.width*ds.width)
 	for _, data := range ds.squareRow {
 		flattened = append(flattened, data...)
 	}

--- a/extendeddatasquare.go
+++ b/extendeddatasquare.go
@@ -280,7 +280,7 @@ func (eds *ExtendedDataSquare) Width() uint {
 
 // Flattened returns the extended data square as a flattened slice of bytes.
 func (eds *ExtendedDataSquare) Flattened() [][]byte {
-	return eds.dataSquare.Flattened()
+	return deepCopy(eds.dataSquare.Flattened())
 }
 
 // FlattenedODS returns the original data square as a flattened slice of bytes.


### PR DESCRIPTION
Protect returned shares by `Flattened()` with deepcopy similar to other exported methods