### PR TITLE
fix: verifyEncoding should revert changes in verifiable data

### DIFF
--- a/rsmt2d_test.go
+++ b/rsmt2d_test.go
@@ -56,13 +56,13 @@ func TestEdsRepairRoundtripSimple(t *testing.T) {
 			flattened[12], flattened[13] = nil, nil
 
 			// Re-import the data square.
-			newEds, err := rsmt2d.ImportExtendedDataSquare(flattened, tt.codec, rsmt2d.NewDefaultTree)
+			eds, err = rsmt2d.ImportExtendedDataSquare(flattened, tt.codec, rsmt2d.NewDefaultTree)
 			if err != nil {
 				t.Errorf("ImportExtendedDataSquare failed: %v", err)
 			}
 
 			// Repair square.
-			err = newEds.Repair(
+			err = eds.Repair(
 				rowRoots,
 				colRoots,
 			)
@@ -70,9 +70,6 @@ func TestEdsRepairRoundtripSimple(t *testing.T) {
 				// err contains information to construct a fraud proof
 				// See extendeddatacrossword_test.go
 				t.Errorf("RepairExtendedDataSquare failed: %v", err)
-			}
-			if !newEds.Equals(eds) {
-				t.Errorf("Repaired ExtendedDataSquare does not match original")
 			}
 		})
 	}

--- a/rsmt2d_test.go
+++ b/rsmt2d_test.go
@@ -56,13 +56,13 @@ func TestEdsRepairRoundtripSimple(t *testing.T) {
 			flattened[12], flattened[13] = nil, nil
 
 			// Re-import the data square.
-			eds, err = rsmt2d.ImportExtendedDataSquare(flattened, tt.codec, rsmt2d.NewDefaultTree)
+			newEds, err := rsmt2d.ImportExtendedDataSquare(flattened, tt.codec, rsmt2d.NewDefaultTree)
 			if err != nil {
 				t.Errorf("ImportExtendedDataSquare failed: %v", err)
 			}
 
 			// Repair square.
-			err = eds.Repair(
+			err = newEds.Repair(
 				rowRoots,
 				colRoots,
 			)
@@ -70,6 +70,9 @@ func TestEdsRepairRoundtripSimple(t *testing.T) {
 				// err contains information to construct a fraud proof
 				// See extendeddatacrossword_test.go
 				t.Errorf("RepairExtendedDataSquare failed: %v", err)
+			}
+			if !newEds.Equals(eds) {
+				t.Errorf("Repaired ExtendedDataSquare does not match original")
 			}
 		})
 	}


### PR DESCRIPTION
The VerifyEncoding function introduced in PR #313 might not revert changes to the original row or column after successful verification. This could lead to a scenario where one of the fields, either squareRow or squareCol, retains a rebuilt share, resulting in only partial repair. This oversight would leave some repaired data unavailable when it should be accessible. Existing tests did not cover this scenario. This PR addresses the issue and includes randomized repair tests to ensure the fix is effective.