### PR TITLE
refactor: return `byzErr` for clarity

### DIFF
--- a/extendeddatacrossword.go
+++ b/extendeddatacrossword.go
@@ -155,6 +155,7 @@ func (eds *ExtendedDataSquare) solveCrosswordRow(
 		var byzErr *ErrByzantineData
 		if errors.As(err, &byzErr) {
 			byzErr.Shares = shares
+			return false, false, byzErr
 		}
 		return false, false, err
 	}
@@ -229,6 +230,7 @@ func (eds *ExtendedDataSquare) solveCrosswordCol(
 		var byzErr *ErrByzantineData
 		if errors.As(err, &byzErr) {
 			byzErr.Shares = shares
+			return false, false, byzErr
 		}
 		return false, false, err
 	}


### PR DESCRIPTION
Closes https://github.com/celestiaorg/rsmt2d/issues/350

This code change is strictly for clarity and it should behave identically to before. These tests still pass:
1. https://github.com/rootulp/rsmt2d/blob/fe785dafe00a1cc6cbdd346be1bd01fd193f758e/extendeddatacrossword_test.go#L185
2. https://github.com/rootulp/rsmt2d/blob/fe785dafe00a1cc6cbdd346be1bd01fd193f758e/extendeddatacrossword_test.go#L346

cc: @odeke-em