### PR TITLE
refactor: use b.Loop() to simplify the code

### DIFF
--- a/codec_test.go
+++ b/codec_test.go
@@ -22,7 +22,7 @@ func BenchmarkEncoding(b *testing.B) {
 		b.Run(
 			fmt.Sprintf("%s 128 shares %d", codecName, shareSize),
 			func(b *testing.B) {
-				for n := 0; n < b.N; n++ {
+				for b.Loop() {
 					encodedData, err := codec.Encode(data)
 					if err != nil {
 						b.Error(err)
@@ -58,7 +58,7 @@ func BenchmarkDecoding(b *testing.B) {
 		b.Run(
 			fmt.Sprintf("%s 128 shares %d", codecName, shareSize),
 			func(b *testing.B) {
-				for n := 0; n < b.N; n++ {
+				for b.Loop() {
 					decodedData, err := codec.Decode(data)
 					if err != nil {
 						b.Error(err)

--- a/datasquare_test.go
+++ b/datasquare_test.go
@@ -421,7 +421,7 @@ func BenchmarkEDSRootsWithDefaultTree(b *testing.B) {
 		b.Run(
 			fmt.Sprintf("%dx%dx%d ODS", i, i, int(square.shareSize)),
 			func(b *testing.B) {
-				for n := 0; n < b.N; n++ {
+				for b.Loop() {
 					square.resetRoots()
 					err := square.computeRoots()
 					assert.NoError(b, err)
@@ -462,7 +462,7 @@ func BenchmarkEDSRootsWithErasuredNMT(b *testing.B) {
 				odsSizeMiBytes, edsSizeMiBytes),
 			func(b *testing.B) {
 				b.ReportAllocs()
-				for n := 0; n < b.N; n++ {
+				for b.Loop() {
 					square.resetRoots()
 					err := square.computeRoots()
 					assert.NoError(b, err)
@@ -501,7 +501,7 @@ func BenchmarkEDSRootsWithBufferedErasuredNMT(b *testing.B) {
 				odsSizeMiBytes, edsSizeMiBytes),
 			func(b *testing.B) {
 				b.ReportAllocs()
-				for n := 0; n < b.N; n++ {
+				for b.Loop() {
 					square.resetRoots()
 					err := square.computeRoots()
 					assert.NoError(b, err)

--- a/extendeddatacrossword_test.go
+++ b/extendeddatacrossword_test.go
@@ -292,7 +292,7 @@ func BenchmarkRepair(b *testing.B) {
 				len(square[0]),
 			),
 			func(b *testing.B) {
-				for n := 0; n < b.N; n++ {
+				for b.Loop() {
 					b.StopTimer()
 
 					flattened := eds.Flattened()

--- a/extendeddatasquare_test.go
+++ b/extendeddatasquare_test.go
@@ -291,7 +291,7 @@ func BenchmarkExtensionEncoding(b *testing.B) {
 			b.Run(
 				fmt.Sprintf("%s %dx%dx%d ODS", codecName, i, i, len(square[0])),
 				func(b *testing.B) {
-					for n := 0; n < b.N; n++ {
+					for b.Loop() {
 						eds, err := ComputeExtendedDataSquare(square, codec, NewDefaultTree)
 						if err != nil {
 							b.Error(err)
@@ -318,7 +318,7 @@ func BenchmarkExtensionWithRoots(b *testing.B) {
 			b.Run(
 				fmt.Sprintf("%s %dx%dx%d ODS", codecName, i, i, len(square[0])),
 				func(b *testing.B) {
-					for n := 0; n < b.N; n++ {
+					for b.Loop() {
 						eds, err := ComputeExtendedDataSquare(square, codec, NewDefaultTree)
 						if err != nil {
 							b.Error(err)


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

replace `for i := range b.N` or `for range b.N` in a benchmark with `for b.Loop()`, and remove any preceding calls to `b.StopTimer`,` b.StartTimer`, and `b.ResetTimer`.

Supported by Go Team, more info: https://go.dev/blog/testing-b-loop
