### PR TITLE
perf: use nmt buffering for root calcuation

### DIFF
--- a/datasquare_test.go
+++ b/datasquare_test.go
@@ -5,11 +5,16 @@ import (
 	"fmt"
 	"math"
 	"reflect"
+	"runtime"
+	"sort"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/celestiaorg/merkletree"
 	"github.com/celestiaorg/nmt"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewDataSquare(t *testing.T) {
@@ -461,6 +466,55 @@ func BenchmarkEDSRootsWithErasuredNMT(b *testing.B) {
 				int(square.shareSize),
 				odsSizeMiBytes, edsSizeMiBytes),
 			func(b *testing.B) {
+				b.ReportAllocs()
+				for n := 0; n < b.N; n++ {
+					square.resetRoots()
+					err := square.computeRoots()
+					assert.NoError(b, err)
+				}
+			},
+		)
+	}
+}
+
+func BenchmarkEDSRootsWithBufferedErasuredNMT(b *testing.B) {
+	const mebibyte = 1024 * 1024            // bytes
+	ODSSizeByteUpperBound := 512 * mebibyte // converting 512 MiB to bytes
+	totalNumberOfShares := float64(ODSSizeByteUpperBound) / shareSize
+	// the closest power of 2 of the square root of
+	// the total number of shares
+	nearestPowerOf2ODSSize := math.Pow(2, math.Ceil(math.Log2(math.Sqrt(
+		totalNumberOfShares))))
+	namespaceIDSize := 8
+
+	for squareSize := 32; squareSize <= int(nearestPowerOf2ODSSize); squareSize *= 2 {
+		// number of shares in the original data square's row/column
+		odsSize := squareSize
+		// number of shares in the extended data square's row/column
+		edsSize := 2 * odsSize
+		// generate an EDS with edsSize X edsSize dimensions in terms of shares.
+		// the generated EDS does not conform to celestia-app specs in terms
+		// of namespace version, also no erasure encoding takes place
+		// yet none of these should impact the benchmarking
+		ds := genRandSortedDS(edsSize, shareSize, namespaceIDSize)
+
+		// a tree constructor for erasured nmt
+		parallelOps := runtime.NumCPU() * 4
+		pool := newTreePool(uint(squareSize), parallelOps, nmt.NamespaceIDSize(namespaceIDSize), nmt.IgnoreMaxNamespace(true), nmt.InitialCapacity(odsSize*2))
+
+		square, err := newDataSquare(ds, pool.NewConstructor(uint(squareSize)), shareSize)
+		require.NoError(b, err)
+		square.setParallelOps(parallelOps)
+		// the total size of the ODS in MiB
+		odsSizeMiBytes := odsSize * odsSize * shareSize / mebibyte
+		// the total size of the EDS in MiB
+		edsSizeMiBytes := 4 * odsSizeMiBytes
+		b.Run(
+			fmt.Sprintf("%dx%dx%d ODS=%dMB, EDS=%dMB", odsSize, odsSize,
+				int(square.shareSize),
+				odsSizeMiBytes, edsSizeMiBytes),
+			func(b *testing.B) {
+				b.ReportAllocs()
 				for n := 0; n < b.N; n++ {
 					square.resetRoots()
 					err := square.computeRoots()
@@ -516,6 +570,178 @@ func (d *errorTree) Push(data []byte) error {
 
 func (d *errorTree) Root() ([]byte, error) {
 	return nil, fmt.Errorf("error")
+}
+
+func TestNmtVsBufferedNmtSameRoot(t *testing.T) {
+	sizes := []struct {
+		name    string
+		odsSize int
+	}{
+		{"ods-32", 32},
+		{"ods-64", 64},
+		{"ods-128", 128},
+		{"ods-256", 256},
+		{"ods-512", 512},
+		// uneven sizes
+		{"ods-35", 35},
+		{"ods-67", 67},
+	}
+
+	t.Run("same-size-pool", func(t *testing.T) {
+		for _, tc := range sizes {
+			t.Run(tc.name, func(t *testing.T) {
+				edsSize := tc.odsSize * 2
+				data := genRandSortedDS(edsSize, shareSize, 8)
+
+				pool := newTreePool(uint(tc.odsSize), 4, nmt.NamespaceIDSize(8), nmt.IgnoreMaxNamespace(true))
+				constructor := newErasuredNamespacedMerkleTreeConstructor(uint64(tc.odsSize), nmt.NamespaceIDSize(8), nmt.IgnoreMaxNamespace(true))
+
+				squareFast, err := newDataSquare(data, pool.NewConstructor(uint(tc.odsSize)), shareSize)
+				require.NoError(t, err)
+				squareFast.setParallelOps(4)
+				squareRoot, err := newDataSquare(data, constructor, shareSize)
+				require.NoError(t, err)
+
+				rowRootsFast, err := squareFast.getRowRoots()
+				require.NoError(t, err)
+				rowRootsRoot, err := squareRoot.getRowRoots()
+				require.NoError(t, err)
+
+				colRootsFast, err := squareFast.getColRoots()
+				require.NoError(t, err)
+				colRootsRoot, err := squareRoot.getColRoots()
+				require.NoError(t, err)
+
+				require.Equal(t, rowRootsFast, rowRootsRoot, "row roots mismatch for ODS size %d", tc.odsSize)
+				require.Equal(t, colRootsFast, colRootsRoot, "column roots mismatch for ODS size %d", tc.odsSize)
+			})
+		}
+	})
+
+	t.Run("pool-reallocation", func(t *testing.T) {
+		// create a pool initialized with the smallest size
+		pool := newTreePool(32, 4, nmt.NamespaceIDSize(8), nmt.IgnoreMaxNamespace(true))
+
+		for _, tc := range sizes {
+			t.Run(tc.name, func(t *testing.T) {
+				edsSize := tc.odsSize * 2
+				data := genRandSortedDS(edsSize, shareSize, 8)
+
+				// use the same pool but with different square sizes to test reallocation
+				squarePooled, err := newDataSquare(data, pool.NewConstructor(uint(tc.odsSize)), shareSize)
+				require.NoError(t, err)
+				squarePooled.setParallelOps(4)
+
+				constructor := newErasuredNamespacedMerkleTreeConstructor(uint64(tc.odsSize), nmt.NamespaceIDSize(8), nmt.IgnoreMaxNamespace(true))
+				squareRegular, err := newDataSquare(data, constructor, shareSize)
+				require.NoError(t, err)
+
+				rowRootsPooled, err := squarePooled.getRowRoots()
+				require.NoError(t, err)
+				colRootsPooled, err := squarePooled.getColRoots()
+				require.NoError(t, err)
+
+				rowRootsRegular, err := squareRegular.getRowRoots()
+				require.NoError(t, err)
+				colRootsRegular, err := squareRegular.getColRoots()
+				require.NoError(t, err)
+
+				require.Equal(t, rowRootsRegular, rowRootsPooled, "row roots mismatch for ODS size %d with pool reallocation", tc.odsSize)
+				require.Equal(t, colRootsRegular, colRootsPooled, "column roots mismatch for ODS size %d with pool reallocation", tc.odsSize)
+			})
+		}
+	})
+}
+
+func TestBufferedNMTParallelismComparison(t *testing.T) {
+	t.Skip("Enable test to measure the best performance for certain num cpu multiplier for parallel rsmt2d computation")
+	type benchmarkResult struct {
+		Multiplier  float64
+		ParallelOps int
+		Duration    time.Duration
+		Iterations  int
+	}
+
+	const (
+		mebibyte        = 1024 * 1024
+		shareSize       = 512
+		namespaceIDSize = 28
+		iterations      = 100 // Total iterations to run
+	)
+
+	cpuMultipliers := []float64{1.0, 1.5, 2.0, 2.5, 3.0, 3.5, 4.0, 4.5, 5.0}
+	squareSize := 512
+
+	odsSize := squareSize
+	edsSize := 2 * odsSize
+
+	ds := genRandSortedDS(edsSize, shareSize, namespaceIDSize)
+
+	odsSizeMiBytes := odsSize * odsSize * shareSize / mebibyte
+	edsSizeMiBytes := 4 * odsSizeMiBytes
+
+	results := make([]benchmarkResult, 0, len(cpuMultipliers))
+
+	fmt.Printf("\n=== Running Benchmarks for 512x512 Square (ODS: %d MB, EDS: %d MB) ===\n", odsSizeMiBytes, edsSizeMiBytes)
+	fmt.Printf("Each configuration: %d iterations\n\n", iterations)
+
+	for _, multiplier := range cpuMultipliers {
+		parallelOps := int(float64(runtime.NumCPU()) * multiplier)
+
+		fmt.Printf("Testing CPU multiplier %.1fx (Parallel Ops: %d)...\n", multiplier, parallelOps)
+
+		pool := newTreePool(
+			uint(squareSize),
+			parallelOps,
+			nmt.NamespaceIDSize(namespaceIDSize),
+			nmt.IgnoreMaxNamespace(true),
+			nmt.InitialCapacity(odsSize*2),
+		)
+
+		square, err := newDataSquare(ds, pool.NewConstructor(uint(squareSize)), shareSize)
+		require.NoError(t, err)
+		square.setParallelOps(parallelOps)
+
+		square.resetRoots()
+		err = square.computeRoots()
+		assert.NoError(t, err)
+
+		start := time.Now()
+		for i := 0; i < iterations; i++ {
+			square.resetRoots()
+			err := square.computeRoots()
+			assert.NoError(t, err)
+		}
+
+		elapsed := time.Since(start)
+		avgDuration := elapsed / time.Duration(iterations)
+
+		results = append(results, benchmarkResult{
+			Multiplier:  multiplier,
+			ParallelOps: parallelOps,
+			Duration:    avgDuration,
+			Iterations:  iterations,
+		})
+
+		fmt.Printf("  Total: %.2f ms, Average: %.2f ms/op\n\n",
+			float64(elapsed.Nanoseconds())/1_000_000, float64(avgDuration.Nanoseconds())/1_000_000)
+	}
+
+	sort.Slice(results, func(i, j int) bool {
+		return results[i].Duration < results[j].Duration
+	})
+
+	fmt.Println("\n=== RESULTS SORTED BY PERFORMANCE (FASTEST FIRST) ===")
+	fmt.Printf("\n%-5s %-10s %-12s %-15s\n",
+		"Rank", "CPU Mult", "Parallel", "Time (ms)")
+	fmt.Println(strings.Repeat("-", 45))
+
+	for i, r := range results {
+		msPerOp := float64(r.Duration.Nanoseconds()) / 1_000_000
+
+		fmt.Printf("%-5d %-10.1f %-12d %-15.2f\n",
+			i+1, r.Multiplier, r.ParallelOps, msPerOp)
+	}
 }
 
 // setCell overwrites the contents of a specific cell. setCell does not perform

--- a/extendeddatasquare.go
+++ b/extendeddatasquare.go
@@ -76,6 +76,21 @@ func ComputeExtendedDataSquare(
 	return &eds, nil
 }
 
+// ComputeExtendedDataSquareWithBuffer computes the extended data square for some shares
+// of original data, it limits parallel operations and uses buffered nmts to avoid allocations when computing root.
+func ComputeExtendedDataSquareWithBuffer(
+	data [][]byte,
+	codec Codec,
+	treeCreator BufferedTreeConstructor,
+) (*ExtendedDataSquare, error) {
+	eds, err := ComputeExtendedDataSquare(data, codec, treeCreator.NewConstructor(uint(getWidth(data))))
+	if err != nil {
+		return nil, err
+	}
+	eds.setParallelOps(treeCreator.TreeCount())
+	return eds, nil
+}
+
 // ImportExtendedDataSquare imports an extended data square, represented as flattened shares of data.
 func ImportExtendedDataSquare(
 	data [][]byte,

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.24.0
 
 require (
 	github.com/celestiaorg/merkletree v0.0.0-20210714075610-a84dc3ddbbe4
-	github.com/celestiaorg/nmt v0.24.1
+	github.com/celestiaorg/nmt v0.24.2-0.20250918161004-dcaa76b80708
 	github.com/klauspost/reedsolomon v1.12.5
 	github.com/stretchr/testify v1.11.1
 	golang.org/x/sync v0.17.0

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/celestiaorg/merkletree v0.0.0-20210714075610-a84dc3ddbbe4 h1:CJdIpo8n
 github.com/celestiaorg/merkletree v0.0.0-20210714075610-a84dc3ddbbe4/go.mod h1:fzuHnhzj1pUygGz+1ZkB3uQbEUL4htqCGJ4Qs2LwMZA=
 github.com/celestiaorg/nmt v0.24.1 h1:MhGKqp257eq2EQQKcva1H/BSYFqIt0Trk8/t3IWfWSw=
 github.com/celestiaorg/nmt v0.24.1/go.mod h1:IhLnJDgCdP70crZFpgihFmU6G+PGeXN37tnMRm+/4iU=
+github.com/celestiaorg/nmt v0.24.2-0.20250918161004-dcaa76b80708 h1:V+Ak590bIn9g3dqYaKDsno8lpvEmjtiFHXDTdguIFoE=
+github.com/celestiaorg/nmt v0.24.2-0.20250918161004-dcaa76b80708/go.mod h1:vgLBpWBi8F5KLxTdXSwb7AU4NhiIQ1AQRGa+PzdcLEA=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/nmtbuffered_tree_test.go
+++ b/nmtbuffered_tree_test.go
@@ -1,0 +1,183 @@
+package rsmt2d
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"fmt"
+
+	"github.com/celestiaorg/nmt"
+)
+
+// treePool provides a fixed-size pool of resizeableBufferTree instances.
+type treePool struct {
+	availableNMTs chan *resizeableBufferTree
+	opts          []nmt.Option
+	poolSize      int
+}
+
+// newTreePool creates a new treePool with the specified configuration.
+func newTreePool(initSquareSize uint, poolSize int, opts ...nmt.Option) *treePool {
+	pool := &treePool{
+		availableNMTs: make(chan *resizeableBufferTree, poolSize),
+		opts:          opts,
+		poolSize:      poolSize,
+	}
+
+	// initialize the pool with trees configured for initSquareSize
+	for i := 0; i < poolSize; i++ {
+		pool.availableNMTs <- newResizeableBufferTree(initSquareSize, 0, pool, opts...)
+	}
+
+	return pool
+}
+
+// acquire retrieves a resizeableBufferTree from the pool.
+func (p *treePool) acquire() *resizeableBufferTree {
+	return <-p.availableNMTs
+}
+
+// release returns a resizeableBufferTree to the pool for reuse.
+func (p *treePool) release(tree *resizeableBufferTree) {
+	p.availableNMTs <- tree
+}
+
+// TreeCount returns the number of trees in the pool.
+func (p *treePool) TreeCount() int {
+	return p.poolSize
+}
+
+// NewConstructor returns a tree constructor function that uses the pool with the specified square size.
+func (p *treePool) NewConstructor(squareSize uint) TreeConstructorFn {
+	return func(_ Axis, axisIndex uint) Tree {
+		tree := p.acquire()
+		tree.resize(squareSize)
+		tree.reset(axisIndex)
+
+		return tree
+	}
+}
+
+var _ Tree = &resizeableBufferTree{}
+
+// resizeableBufferTree is a wrapper around NamespaceMerkleTree with buffer pooling support
+// for efficient memory management in high-throughput scenarios.
+type resizeableBufferTree struct {
+	squareSize    uint // note: this refers to the width of the original square before erasure-coded
+	maxSquareSize uint // maximum square size this tree's buffer can handle without reallocation
+	options       []nmt.Option
+	tree          *nmt.NamespacedMerkleTree
+	// axisIndex is the index of the axis (row or column) that this tree is on. This is passed
+	// by rsmt2d and used to help determine which quadrant each leaf belongs to.
+	axisIndex uint
+	// shareIndex is the index of the share in a row or column that is being
+	// pushed to the tree. It is expected to be in the range: 0 <= shareIndex <
+	// 2*squareSize. shareIndex is used to help determine which quadrant each
+	// leaf belongs to, along with keeping track of how many leaves have been
+	// added to the tree so far.
+	shareIndex      uint
+	namespaceSize   int
+	parityNamespace []byte
+	pool            *treePool // reference to the pool this tree belongs to
+	buffer          []byte    // Pre-allocated buffer for share data
+	bufferEntrySize int
+}
+
+// newResizeableBufferTree creates a new resizeableBufferTree with pre-allocated buffer and pool reference.
+func newResizeableBufferTree(maxSquareSize uint, axisIndex uint, pool *treePool, options ...nmt.Option) *resizeableBufferTree {
+	if maxSquareSize == 0 {
+		panic("cannot create a resizeableBufferTree of maxSquareSize == 0")
+	}
+	if pool == nil {
+		panic("cannot create a resizeableBufferTree of pool == nil")
+	}
+	opts := &nmt.Options{}
+	for _, setter := range options {
+		setter(opts)
+	}
+	options = append(options, nmt.IgnoreMaxNamespace(true), nmt.ReuseBuffer(true))
+	tree := nmt.New(sha256.New(), options...)
+	namespaceSize := int(opts.NamespaceIDSize)
+	entrySize := shareSize + namespaceSize
+	return &resizeableBufferTree{
+		squareSize:      maxSquareSize,
+		maxSquareSize:   maxSquareSize,
+		options:         options,
+		tree:            tree,
+		pool:            pool,
+		bufferEntrySize: entrySize,
+		namespaceSize:   namespaceSize,
+		parityNamespace: bytes.Repeat([]byte{0xFF}, namespaceSize),
+		axisIndex:       axisIndex,
+		buffer:          make([]byte, 2*maxSquareSize*uint(entrySize)),
+		shareIndex:      0,
+	}
+}
+
+// Push adds share data to the tree using the pre-allocated buffer to avoid memory allocation.
+func (t *resizeableBufferTree) Push(data []byte) error {
+	if t.axisIndex+1 > 2*t.squareSize || t.shareIndex+1 > 2*t.squareSize {
+		return fmt.Errorf("pushed past predetermined square size: boundary at %d index at %d %d", 2*t.squareSize, t.axisIndex, t.shareIndex)
+	}
+	if len(data) < t.namespaceSize {
+		return fmt.Errorf("data is too short to contain namespace ID")
+	}
+	var (
+		nidAndData []byte
+		nidDataLen = t.namespaceSize + len(data)
+	)
+
+	if nidDataLen > t.bufferEntrySize {
+		return fmt.Errorf("data is too large to be used with allocated buffer")
+	}
+	offset := int(t.shareIndex) * t.bufferEntrySize
+	nidAndData = t.buffer[offset : offset+nidDataLen]
+
+	copy(nidAndData[t.namespaceSize:], data)
+	// use the parity namespace if the cell is not in Q0 of the extended data square
+	if t.isQuadrantZero() {
+		copy(nidAndData[:t.namespaceSize], data[:t.namespaceSize])
+	} else {
+		copy(nidAndData[:t.namespaceSize], t.parityNamespace)
+	}
+	err := t.tree.Push(nidAndData)
+	if err != nil {
+		return err
+	}
+	t.incrementShareIndex()
+	return nil
+}
+
+// Root calculates the tree root using FastRoot and releases the tree back to the pool.
+func (t *resizeableBufferTree) Root() ([]byte, error) {
+	defer t.pool.release(t)
+	return t.tree.Root()
+}
+
+// incrementShareIndex advances to the next share position in the tree.
+func (t *resizeableBufferTree) incrementShareIndex() {
+	t.shareIndex++
+}
+
+// isQuadrantZero checks if the current position is in the original (non-parity) data quadrant.
+func (t *resizeableBufferTree) isQuadrantZero() bool {
+	return t.shareIndex < t.squareSize && t.axisIndex < t.squareSize
+}
+
+// resize adjusts the tree's square size and resizes the buffer if the new size exceeds the current maximum capacity.
+func (t *resizeableBufferTree) resize(squareSize uint) {
+	if t.squareSize != squareSize {
+		t.squareSize = squareSize
+		if squareSize > t.maxSquareSize {
+			entrySize := t.bufferEntrySize
+			t.buffer = make([]byte, 2*squareSize*uint(entrySize))
+			t.maxSquareSize = squareSize
+		}
+	}
+}
+
+// reset reinitializes the resizeableBufferTree for reuse.
+func (t *resizeableBufferTree) reset(axisIndex uint) {
+	t.axisIndex = axisIndex
+	t.shareIndex = 0
+	t.tree.Reset()
+}

--- a/tree.go
+++ b/tree.go
@@ -10,6 +10,11 @@ import (
 // inside of rsmt2d.
 type TreeConstructorFn = func(axis Axis, index uint) Tree
 
+type BufferedTreeConstructor interface {
+	NewConstructor(squareSize uint) TreeConstructorFn
+	TreeCount() int
+}
+
 // SquareIndex contains all information needed to identify the cell that is being
 // pushed
 type SquareIndex struct {


### PR DESCRIPTION
## Overview
Use buffering approach during root calculation: 
- each tree has buffer for leaves which is 