### PR TITLE
ci: resolve code-scanning findings (pin actions, restrict token permissions)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,9 +10,15 @@ on:
 env:
   GO_VERSION: '1.25'
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     strategy:
       fail-fast: false
       matrix:
@@ -23,7 +29,7 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
       - uses: actions/checkout@v6
-      - uses: technote-space/get-diff-action@v6
+      - uses: technote-space/get-diff-action@f27caffdd0fb9b13f4fc191c016bb4e0632844af # v6
         with:
           PATTERNS: |
             **/**.go
@@ -36,7 +42,7 @@ jobs:
         run: |
           GOARCH=${{ matrix.goarch }} go test ./... -mod=readonly -timeout 8m -race -coverprofile=coverage.txt -covermode=atomic
         if: env.GIT_DIFF
-      - uses: codecov/codecov-action@v6.0.0
+      - uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
         with:
           file: ./coverage.txt
         if: env.GIT_DIFF

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,6 +11,9 @@ on:
 env:
   GO_VERSION: '1.25'
 
+permissions:
+  contents: read
+
 jobs:
   golangci-lint:
     name: golangci-lint
@@ -21,7 +24,7 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version: ${{ env.GO_VERSION }}
-      - uses: golangci/golangci-lint-action@v9.2.0
+      - uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:
           args: --timeout 10m
           github-token: ${{ secrets.github_token }}


### PR DESCRIPTION
## Summary

Resolves all 5 open GitHub code-scanning alerts on the `main` branch:

- **`actions/unpinned-tag`** (alerts #4, #14, #17): pinned `codecov/codecov-action`, `golangci/golangci-lint-action`, and `technote-space/get-diff-action` to commit SHAs with the version as a trailing comment, per GitHub's recommended format.
- **`actions/missing-workflow-permissions`** (alerts #2, #11): added workflow-level `permissions: contents: read` to both workflows. The `test` job in `ci.yml` additionally gets `id-token: write` at the job level for Codecov's OIDC tokenless upload (job-level permissions fully replace workflow-level in Actions, so `contents: read` is restated there).

See https://github.com/celestiaorg/rsmt2d/security/code-scanning for the original findings.

## Test plan

- [ ] `Tests` workflow passes on this PR (validates `ci.yml` still works end-to-end, including Codecov upload)
- [ ] `lint` workflow passes on this PR (validates `lint.yml` still works)
- [ ] After merge, the 5 alerts (#2, #4, #11, #14, #17) transition from `open` to `fixed` on the repo's code-scanning page

🤖 Generated with [Claude Code](https://claude.com/claude-code)