### PR TITLE
docs: fix incorrect comment on dataSquare

### DIFF
--- a/datasquare.go
+++ b/datasquare.go
@@ -14,8 +14,10 @@ import (
 var ErrUnevenChunks = errors.New("non-nil shares not all of equal size")
 
 // dataSquare stores all data for an original data square (ODS) or extended
-// data square (EDS). Data is duplicated in both row-major and column-major
-// order in order to be able to provide zero-allocation column slices.
+// data square (EDS). Pointers to the shares are stored in both row-major
+// (squareRow) and column-major (squareCol) order. Both layouts reference the
+// same underlying share byte slices (the share bytes themselves are not
+// duplicated), which enables zero-allocation row and column slices.
 type dataSquare struct {
 	squareRow    [][][]byte // row-major
 	squareCol    [][][]byte // col-major


### PR DESCRIPTION
## Overview

Fixes the misleading comment on the `dataSquare` type. The comment claimed that share data is "duplicated in both row-major and column-major order", but this is not what the code does.

In `newDataSquare`:
- `squareRow[rowIdx] = data[rowIdx*width : rowIdx*width+width]` stores sub-slices of `data`.
- `squareCol[colIdx][rowIdx] = data[rowIdx*width+colIdx]` stores the same `[]byte` elements.

So `squareRow[rowIdx][colIdx]` and `squareCol[colIdx][rowIdx]` both hold the **same `[]byte` slice header**, pointing to the same backing array. Only the pointers/references are arranged in two layouts; the underlying share bytes are **not** duplicated. `SetCell`, `setRowSlice`, and `setColSlice` confirm this by writing the identical pointer into both layouts.

As noted in the issue, [PR #52](https://github.com/celestiaorg/rsmt2d/pull/52) was supposed to introduce the duplication but assigned slices rather than copying bytes, so the duplication never happened; the benchmark improvements there came from reduced allocations elsewhere.

This PR updates the comment to accurately describe the data structure.

Closes https://github.com/celestiaorg/rsmt2d/issues/280

🤖 Generated with [Claude Code](https://claude.com/claude-code)