### PR TITLE
fix: return correct axis shares in ErrByzantineData

### DIFF
--- a/extendeddatacrossword.go
+++ b/extendeddatacrossword.go
@@ -154,7 +154,10 @@ func (eds *ExtendedDataSquare) solveCrosswordRow(
 	if err != nil {
 		var byzErr *ErrByzantineData
 		if errors.As(err, &byzErr) {
-			byzErr.Shares = shares
+			// The byzantine row is the one being solved. Snapshot it from the
+			// EDS (not the codec's in-place output, which has filled the missing
+			// shares) so the error preserves the original nil placeholders.
+			byzErr.Shares = copyShares(eds.row(uint(rowIdx)))
 			return false, false, byzErr
 		}
 		return false, false, err
@@ -171,13 +174,15 @@ func (eds *ExtendedDataSquare) solveCrosswordRow(
 			if err != nil {
 				var byzErr *ErrByzantineData
 				if errors.As(err, &byzErr) {
-					byzErr.Shares = shares
+					// The byzantine axis is the orthogonal column, so attach the
+					// column's shares (not the row being solved).
+					byzErr.Shares = copyShares(col)
 				}
 				return false, false, err
 			}
 
 			if eds.verifyEncoding(col, rowIdx, rebuiltShares[colIdx]) != nil {
-				return false, false, &ErrByzantineData{Col, uint(colIdx), col}
+				return false, false, &ErrByzantineData{Col, uint(colIdx), copyShares(col)}
 			}
 		}
 	}
@@ -229,7 +234,10 @@ func (eds *ExtendedDataSquare) solveCrosswordCol(
 	if err != nil {
 		var byzErr *ErrByzantineData
 		if errors.As(err, &byzErr) {
-			byzErr.Shares = shares
+			// The byzantine column is the one being solved. Snapshot it from the
+			// EDS (not the codec's in-place output, which has filled the missing
+			// shares) so the error preserves the original nil placeholders.
+			byzErr.Shares = copyShares(eds.col(uint(colIdx)))
 			return false, false, byzErr
 		}
 		return false, false, err
@@ -246,13 +254,15 @@ func (eds *ExtendedDataSquare) solveCrosswordCol(
 			if err != nil {
 				var byzErr *ErrByzantineData
 				if errors.As(err, &byzErr) {
-					byzErr.Shares = shares
+					// The byzantine axis is the orthogonal row, so attach the
+					// row's shares (not the column being solved).
+					byzErr.Shares = copyShares(row)
 				}
 				return false, false, err
 			}
 
 			if eds.verifyEncoding(row, colIdx, rebuiltShares[rowIdx]) != nil {
-				return false, false, &ErrByzantineData{Row, uint(rowIdx), row}
+				return false, false, &ErrByzantineData{Row, uint(rowIdx), copyShares(row)}
 			}
 		}
 	}
@@ -416,6 +426,22 @@ func (eds *ExtendedDataSquare) preRepairSanityCheck(
 	}
 
 	return errs.Wait()
+}
+
+// copyShares returns a deep copy of shares, preserving nil entries. It is used
+// to snapshot a byzantine row or column for ErrByzantineData so that the
+// returned shares are not affected by subsequent in-place mutation of the EDS
+// (e.g. via SetCell) or by the Reed-Solomon codec's in-place Decode.
+func copyShares(shares [][]byte) [][]byte {
+	out := make([][]byte, len(shares))
+	for i, share := range shares {
+		if share == nil {
+			continue
+		}
+		out[i] = make([]byte, len(share))
+		copy(out[i], share)
+	}
+	return out
 }
 
 func noMissingData(input [][]byte, rebuiltIndex int) bool {

--- a/extendeddatacrossword.go
+++ b/extendeddatacrossword.go
@@ -157,7 +157,7 @@ func (eds *ExtendedDataSquare) solveCrosswordRow(
 			// The byzantine row is the one being solved. Snapshot it from the
 			// EDS (not the codec's in-place output, which has filled the missing
 			// shares) so the error preserves the original nil placeholders.
-			byzErr.Shares = copyShares(eds.row(uint(rowIdx)))
+			byzErr.Shares = eds.Row(uint(rowIdx))
 			return false, false, byzErr
 		}
 		return false, false, err
@@ -176,13 +176,13 @@ func (eds *ExtendedDataSquare) solveCrosswordRow(
 				if errors.As(err, &byzErr) {
 					// The byzantine axis is the orthogonal column, so attach the
 					// column's shares (not the row being solved).
-					byzErr.Shares = copyShares(col)
+					byzErr.Shares = deepCopy(col)
 				}
 				return false, false, err
 			}
 
 			if eds.verifyEncoding(col, rowIdx, rebuiltShares[colIdx]) != nil {
-				return false, false, &ErrByzantineData{Col, uint(colIdx), copyShares(col)}
+				return false, false, &ErrByzantineData{Col, uint(colIdx), deepCopy(col)}
 			}
 		}
 	}
@@ -237,7 +237,7 @@ func (eds *ExtendedDataSquare) solveCrosswordCol(
 			// The byzantine column is the one being solved. Snapshot it from the
 			// EDS (not the codec's in-place output, which has filled the missing
 			// shares) so the error preserves the original nil placeholders.
-			byzErr.Shares = copyShares(eds.col(uint(colIdx)))
+			byzErr.Shares = eds.Col(uint(colIdx))
 			return false, false, byzErr
 		}
 		return false, false, err
@@ -256,13 +256,13 @@ func (eds *ExtendedDataSquare) solveCrosswordCol(
 				if errors.As(err, &byzErr) {
 					// The byzantine axis is the orthogonal row, so attach the
 					// row's shares (not the column being solved).
-					byzErr.Shares = copyShares(row)
+					byzErr.Shares = deepCopy(row)
 				}
 				return false, false, err
 			}
 
 			if eds.verifyEncoding(row, colIdx, rebuiltShares[rowIdx]) != nil {
-				return false, false, &ErrByzantineData{Row, uint(rowIdx), copyShares(row)}
+				return false, false, &ErrByzantineData{Row, uint(rowIdx), deepCopy(row)}
 			}
 		}
 	}
@@ -426,22 +426,6 @@ func (eds *ExtendedDataSquare) preRepairSanityCheck(
 	}
 
 	return errs.Wait()
-}
-
-// copyShares returns a deep copy of shares, preserving nil entries. It is used
-// to snapshot a byzantine row or column for ErrByzantineData so that the
-// returned shares are not affected by subsequent in-place mutation of the EDS
-// (e.g. via SetCell) or by the Reed-Solomon codec's in-place Decode.
-func copyShares(shares [][]byte) [][]byte {
-	out := make([][]byte, len(shares))
-	for i, share := range shares {
-		if share == nil {
-			continue
-		}
-		out[i] = make([]byte, len(share))
-		copy(out[i], share)
-	}
-	return out
 }
 
 func noMissingData(input [][]byte, rebuiltIndex int) bool {

--- a/extendeddatacrossword_test.go
+++ b/extendeddatacrossword_test.go
@@ -309,6 +309,101 @@ func TestRepairVerifiesOrthogonalVectorsAgainstRoots(t *testing.T) {
 	require.Equal(t, uint(2), byzData.Index, "Byzantine error must be on column index 2")
 }
 
+// TestErrByzantineDataSharesMatchOrthogonalAxis is a regression test for
+// GHSA-jfh3-xj5q-rm8x. When Repair detects byzantine data on an orthogonal axis
+// (e.g. a column completed during a row solve), ErrByzantineData.Shares must
+// carry the shares of the axis named by the error (Axis/Index), not the shares
+// of the axis currently being solved. Previously the solver attached the
+// in-progress row's shares to a column-axis error, so a downstream consumer
+// building a bad-encoding fraud proof would point at the wrong vector and the
+// proof would be unverifiable.
+func TestErrByzantineDataSharesMatchOrthogonalAxis(t *testing.T) {
+	corruptShare := bytes.Repeat([]byte{66}, shareSize)
+	codec := NewLeoRSCodec()
+
+	eds := createTestEds(codec, shareSize)
+	rowRoots, err := eds.getRowRoots()
+	require.NoError(t, err)
+	colRoots, err := eds.getColRoots()
+	require.NoError(t, err)
+
+	// Same corruption as TestRepairVerifiesOrthogonalVectorsAgainstRoots: the
+	// byzantine cell (2, 2) is only surfaced when row 0's rebuild of (0, 2)
+	// completes column 2, so the error names column 2 (orthogonal to the row
+	// solve in progress).
+	//
+	// O O _ O      _ = nil share
+	// O O O O      C = corrupted share
+	// _ O C O      O = original/parity share
+	// O O O O
+	eds.setCell(0, 2, nil)
+	eds.setCell(2, 0, nil)
+	eds.setCell(2, 2, corruptShare)
+
+	err = eds.Repair(rowRoots, colRoots)
+	var byzData *ErrByzantineData
+	require.ErrorAs(t, err, &byzData)
+	require.Equal(t, Col, byzData.Axis, "Byzantine error must be on the column axis")
+	require.Equal(t, uint(2), byzData.Index, "Byzantine error must be on column index 2")
+
+	// The shares attached to the error must be column 2's shares. Column 2
+	// contains the corrupt cell at (2, 2); row 0 (the axis being solved) does
+	// not. Before the fix Shares was set to row 0, so this assertion fails.
+	require.Equal(t, int(eds.Width()), len(byzData.Shares))
+	assert.Contains(t, byzData.Shares, corruptShare,
+		"Shares must contain the corrupt cell that lives on the byzantine (column) axis")
+	// The share at the rebuilt index (row 0 of column 2) was missing prior to
+	// repair and must remain nil, as the ErrByzantineData doc comment promises.
+	assert.Nil(t, byzData.Shares[0],
+		"missing share at the rebuilt index must remain nil")
+}
+
+// TestErrByzantineDataSharesPreserveNils is a regression test for
+// GHSA-jfh3-xj5q-rm8x. The ErrByzantineData doc comment promises that missing
+// shares are nil, but LeoRSCodec.Decode reconstructs missing shares in place.
+// The solver previously attached that mutated buffer to the error, so the nil
+// placeholders a fraud-proof consumer relies on were silently filled with
+// reconstructed (uncommitted) shares. Repair must instead return a snapshot of
+// the byzantine row/column prior to repair, with missing shares as nil.
+func TestErrByzantineDataSharesPreserveNils(t *testing.T) {
+	corruptShare := bytes.Repeat([]byte{66}, shareSize)
+	codec := NewLeoRSCodec()
+
+	eds := createTestEds(codec, shareSize)
+	rowRoots, err := eds.getRowRoots()
+	require.NoError(t, err)
+	colRoots, err := eds.getColRoots()
+	require.NoError(t, err)
+
+	// Corrupt (0, 0) and remove (0, 2), (0, 3), and (3, 0). No row or column is
+	// complete pre-repair, so preRepairSanityCheck does not short-circuit. When
+	// solveCrosswordRow rebuilds row 0 from the corrupt (0, 0) and honest (0, 1),
+	// the rebuilt row fails its own row root, producing a Row-axis byzantine
+	// error whose Shares must preserve the two nils at (0, 2) and (0, 3).
+	//
+	// C O _ _      _ = nil share
+	// O O O O      C = corrupted share
+	// O O O O      O = original/parity share
+	// _ O O O
+	eds.setCell(0, 0, corruptShare)
+	eds.setCell(0, 2, nil)
+	eds.setCell(0, 3, nil)
+	eds.setCell(3, 0, nil)
+
+	err = eds.Repair(rowRoots, colRoots)
+	var byzData *ErrByzantineData
+	require.ErrorAs(t, err, &byzData)
+	require.Equal(t, Row, byzData.Axis, "Byzantine error must be on the row axis")
+	require.Equal(t, uint(0), byzData.Index, "Byzantine error must be on row index 0")
+
+	require.Equal(t, int(eds.Width()), len(byzData.Shares))
+	assert.Contains(t, byzData.Shares, corruptShare)
+	// Positions 2 and 3 of row 0 were missing prior to repair. Before the fix,
+	// Decode filled them in place, so they were non-nil.
+	assert.Nil(t, byzData.Shares[2], "missing share at (0, 2) must remain nil")
+	assert.Nil(t, byzData.Shares[3], "missing share at (0, 3) must remain nil")
+}
+
 func BenchmarkRepair(b *testing.B) {
 	// For different ODS sizes
 	for originalDataWidth := 4; originalDataWidth <= 512; originalDataWidth *= 2 {

--- a/leopard.go
+++ b/leopard.go
@@ -44,6 +44,10 @@ func (l *LeoRSCodec) Encode(data [][]byte) ([][]byte, error) {
 	return shares[dataLen:], nil
 }
 
+// Decode reconstructs missing shares from the provided data. Missing shares
+// must be nil. The returned slice is the same slice as data: Reconstruct fills
+// the nil entries in place, so callers that need to retain the original
+// (nil-preserving) input must copy it before calling Decode.
 func (l *LeoRSCodec) Decode(data [][]byte) ([][]byte, error) {
 	half := len(data) / 2
 	enc, err := l.loadOrInitEncoder(half)


### PR DESCRIPTION
## Overview

Closes [PROTOCO-1758](https://linear.app/celestia/issue/PROTOCO-1758/resolve-2-security-advisories-on-rsmt2d).

Security advisory: GHSA-jfh3-xj5q-rm8x (details intentionally omitted here; see the advisory and Linear issue).

## What changed

- `Repair` now populates `ErrByzantineData.Shares` with the shares of the axis named by the error, snapshotted from the EDS so the original `nil` placeholders are preserved.
- Documented that `LeoRSCodec.Decode` mutates its input in place.
- Added regression tests covering the byzantine-share axis and nil-preservation guarantees.

## Testing

- `go test ./...` passes.
- `golangci-lint run` reports 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)